### PR TITLE
로그인 페이지 #57, #58 버그 수정

### DIFF
--- a/packages/client/src/pages/Signin/index.tsx
+++ b/packages/client/src/pages/Signin/index.tsx
@@ -1,6 +1,8 @@
-import axios, { AxiosError } from 'axios';
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import axios, { AxiosError } from 'axios';
+
+import { chkUser } from 'types/Signin';
 import { Container, Logo, NaverOAuth } from './styled';
 
 function Signin() {
@@ -10,6 +12,11 @@ function Signin() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
+  /**
+   * 네이버 OAuth 로그인 버튼 클릭 시, 실행되는 함수
+   *
+   * 네이버 로그인을 위한 링크로 이동
+   */
   const handleClickOAuth = useCallback(() => {
     if (!naverOAuthURL) return;
 
@@ -17,28 +24,43 @@ function Signin() {
   }, [naverOAuthURL]);
 
   /**
-   * 메인 페이지 접속 시, 쿼리스트링 여부 판단
+   * 네이버 OAuth 리다이렉트 받은 이후 가입 여부 확인
    *
-   * 쿼리 스트링 존재하면 로그인 진행중
+   * 서버 응답에 따라 페이지 라우팅
+   *
+   * @params { code, state }: OAuth 리다이렉트 응답 받은 쿼리
    */
-  useEffect(() => {
-    const code = searchParams.get('code');
+  const chkUser = useCallback(
+    async ({ code, state }: chkUser) => {
     const state = searchParams.get('state');
 
-    if (!code || !state) return;
-
-    axios
-      .get(`${api}/user/naver-oauth?code=${code}&state=${state}`, {
-        withCredentials: true,
-      })
-      .then((res) => {
+      try {
+        await axios.get(`${api}/user/naver-oauth?code=${code}&state=${state}`, {
+          withCredentials: true,
+        });
         navigate('/home');
-      })
-      .catch((err: AxiosError) => {
-        if (err.response && err.response.status === 303) navigate('/signup');
+      } catch (err) {
+        const axiosError = err instanceof AxiosError;
+
+        if (axiosError && err.response?.status === 303) navigate('/signup');
         else navigate('/');
-      });
-  }, [searchParams, navigate, api]);
+      }
+    },
+    [api, navigate]
+  );
+
+  /**
+   * 메인 페이지 접속 시, 쿼리 존재 여부 판단
+   *
+   * 네이버 OAuth 리다이렉트를 받아 쿼리 존재하면 가입여부 확인 진행
+   */
+  const code = searchParams.get('code');
+  const state = searchParams.get('state');
+
+  if (code && state) {
+    chkUser({ code, state });
+    return <p>...loading</p>;
+  }
 
   return (
     <Container>

--- a/packages/client/src/pages/Signin/index.tsx
+++ b/packages/client/src/pages/Signin/index.tsx
@@ -32,7 +32,7 @@ function Signin() {
    */
   const chkUser = useCallback(
     async ({ code, state }: chkUser) => {
-    const state = searchParams.get('state');
+      window.history.replaceState(null, '', '/');
 
       try {
         await axios.get(`${api}/user/naver-oauth?code=${code}&state=${state}`, {

--- a/packages/client/src/types/Signin.ts
+++ b/packages/client/src/types/Signin.ts
@@ -1,0 +1,4 @@
+export interface chkUser {
+  code: string;
+  state: string;
+}


### PR DESCRIPTION
## 📕 제목

- #57 
- #58 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 리다이렉트 이후 로그인 페이지 렌더링되는 버그 수정
  - 로딩중 화면 표시
- [x] 회원가입 또는 로그인 성공 이후 뒤로가기 진행 시, 기존 쿼리로 다시 로그인 요청하는 버그 수정
  - 리다이렉트로 쿼리 받자마자 `window.history.replaceState` 이용하여 쿼리 삭제
- [x] 사용하는 타입 인터페이스 `types` 폴더 내에 추가
- [x] axios 요청 async/await 로 변경
- [x] 함수 주석 추가

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 로딩 컴포넌트 제작하여 리팩토링 필요
