### PR TITLE
Footer 및 메뉴 리스트 페이지 기본 구현

### DIFF
--- a/packages/client/src/Router.tsx
+++ b/packages/client/src/Router.tsx
@@ -1,7 +1,8 @@
 import { Route, Routes } from 'react-router-dom';
-import Signup from './pages/Signup';
-import Signin from './pages/Signin';
-import OrderList from './pages/customer/OrderList';
+import Signup from 'pages/Signup';
+import Signin from 'pages/Signin';
+import OrderList from 'pages/customer/OrderList';
+import MenuList from 'pages/MenuList';
 
 function Router() {
   return (
@@ -10,7 +11,8 @@ function Router() {
       <Route path={'/signup'} element={<Signup />}></Route> {/* 회원가입 */}
       <Route path={'/mypage'} element={<></>}></Route> {/* 마이페이지 */}
       <Route path={'/home'} element={<OrderList />}></Route> {/* 고객 메인 */}
-      <Route path={'/menu'} element={<></>}></Route> {/* 고객 메뉴 목록 */}
+      <Route path={'/menu'} element={<MenuList />}></Route>{' '}
+      {/* 고객 메뉴 목록 */}
       <Route path={'/menu/:menuId'} element={<></>}></Route>{' '}
       {/* 고객 메뉴 상세 */}
       <Route path={'/cart'} element={<></>}></Route> {/* 고객 장바구니 */}

--- a/packages/client/src/components/Footer/index.tsx
+++ b/packages/client/src/components/Footer/index.tsx
@@ -1,0 +1,58 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { FooterWrapper, NavWrapper } from './styled';
+
+function Footer() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [currentPath, setCurrentPath] = useState<string>();
+
+  const handleClickHome = (e: React.MouseEvent) => {
+    navigate('/home');
+  };
+
+  const handleClickOrder = (e: React.MouseEvent) => {
+    navigate('/menu');
+  };
+
+  const handleClickMY = (e: React.MouseEvent) => {
+    navigate('/mypage');
+  };
+
+  const findPath = () => {
+    if (/home/.test(location.pathname)) setCurrentPath('home');
+    else if (/menu|order/.test(location.pathname)) setCurrentPath('order');
+    else if (/mypage/.test(location.pathname)) setCurrentPath('mypage');
+  };
+
+  useEffect(() => {
+    findPath();
+  }, []);
+
+  return (
+    <FooterWrapper>
+      <NavWrapper>
+        <p
+          className={currentPath === 'home' ? 'selected' : ''}
+          onClick={handleClickHome}
+        >
+          Home
+        </p>
+        <p
+          className={currentPath === 'order' ? 'selected' : ''}
+          onClick={handleClickOrder}
+        >
+          Order
+        </p>
+        <p
+          className={currentPath === 'mypage' ? 'selected' : ''}
+          onClick={handleClickMY}
+        >
+          MY
+        </p>
+      </NavWrapper>
+    </FooterWrapper>
+  );
+}
+
+export default Footer;

--- a/packages/client/src/components/Footer/styled.ts
+++ b/packages/client/src/components/Footer/styled.ts
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+
+export const FooterWrapper = styled.footer`
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 3rem;
+  box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5),
+    0px 0px 4px rgba(0, 0, 0, 0.25);
+`;
+
+export const NavWrapper = styled.nav`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+
+  p{
+    color: ${(props) => props.theme.colors.tertiary};
+  }
+
+  p.selected{
+    color: ${(props) => props.theme.colors.primary};
+  }
+`

--- a/packages/client/src/components/MenuItem/index.tsx
+++ b/packages/client/src/components/MenuItem/index.tsx
@@ -10,7 +10,7 @@ function MenuItem(props: Menu) {
   };
 
   return (
-    <MenuWrapper key={props.id} onClick={handleClickMenuItem}>
+    <MenuWrapper key={props.id} onClick={handleClickMenuItem} data-testid={'menu-item'}>
       <MenuImg src={props.thumbnail} alt="메뉴 이미지" />
       <MenuInfoWrapper>
         <p>{props.name}</p>

--- a/packages/client/src/components/MenuItem/index.tsx
+++ b/packages/client/src/components/MenuItem/index.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { Menu } from '@/types/MenuList';
+import { MenuImg, MenuWrapper, MenuInfoWrapper } from './styled';
 
 function MenuItem(props: Menu) {
   const navigate = useNavigate();
@@ -9,11 +10,13 @@ function MenuItem(props: Menu) {
   };
 
   return (
-    <li key={props.id} onClick={handleClickMenuItem}>
-      <img src={props.thumbnail} alt="메뉴 이미지" />
-      <p>{props.name}</p>
-      <p>{props.price}</p>
-    </li>
+    <MenuWrapper key={props.id} onClick={handleClickMenuItem}>
+      <MenuImg src={props.thumbnail} alt="메뉴 이미지" />
+      <MenuInfoWrapper>
+        <p>{props.name}</p>
+        <p>{props.price}</p>
+      </MenuInfoWrapper>
+    </MenuWrapper>
   );
 }
 

--- a/packages/client/src/components/MenuItem/index.tsx
+++ b/packages/client/src/components/MenuItem/index.tsx
@@ -1,0 +1,20 @@
+import { useNavigate } from 'react-router-dom';
+import { Menu } from '@/types/MenuList';
+
+function MenuItem(props: Menu) {
+  const navigate = useNavigate();
+
+  const handleClickMenuItem = () => {
+    navigate(`/menu/${props.id}`);
+  };
+
+  return (
+    <li key={props.id} onClick={handleClickMenuItem}>
+      <img src={props.thumbnail} alt="메뉴 이미지" />
+      <p>{props.name}</p>
+      <p>{props.price}</p>
+    </li>
+  );
+}
+
+export default MenuItem;

--- a/packages/client/src/components/MenuItem/styled.ts
+++ b/packages/client/src/components/MenuItem/styled.ts
@@ -1,0 +1,1 @@
+import styled from "@emotion/styled";

--- a/packages/client/src/components/MenuItem/styled.ts
+++ b/packages/client/src/components/MenuItem/styled.ts
@@ -1,1 +1,21 @@
-import styled from "@emotion/styled";
+import styled from '@emotion/styled';
+
+export const MenuWrapper = styled.li`
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  width: 100%;
+  margin: 1rem 0 1rem 0;
+`;
+
+export const MenuImg = styled.img`
+  width: 5rem;
+  border-radius: 50%;
+`;
+
+export const MenuInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.3rem;
+`

--- a/packages/client/src/components/SnackBar/index.tsx
+++ b/packages/client/src/components/SnackBar/index.tsx
@@ -1,0 +1,22 @@
+import { useRecoilValue } from 'recoil';
+import { useNavigate } from 'react-router-dom';
+import { cartState } from 'utils/store';
+import { SnackBarWrapper } from './styled';
+
+function SnackBar() {
+  const cart = useRecoilValue(cartState);
+  const navigate = useNavigate();
+
+  const handleClickCart = () => {
+    navigate('/cart')
+  }
+
+  return (
+    <SnackBarWrapper>
+      <p>주문할 매장을 선택해주세요</p>
+      <p onClick={handleClickCart}>장바구니 {cart.length}개</p>
+    </SnackBarWrapper>
+  );
+}
+
+export default SnackBar;

--- a/packages/client/src/components/SnackBar/styled.ts
+++ b/packages/client/src/components/SnackBar/styled.ts
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+export const SnackBarWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-direction: row;
+  position: fixed;
+  bottom: 3rem;
+  width: 100%;
+  height: 2.5rem;
+  padding: 0 1rem 0 1rem;
+  background-color: ${(props) => props.theme.colors.secondary};
+  color: white;
+  font-weight: ${(props) => props.theme.font.weight.bold500};
+`;

--- a/packages/client/src/pages/MenuList/index.spec.tsx
+++ b/packages/client/src/pages/MenuList/index.spec.tsx
@@ -1,1 +1,64 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { MemoryRouter } from 'react-router-dom';
+import Router from '@/Router';
+import Layout from '@/Layout';
+
+const api = process.env.REACT_APP_API_SERVER_BASE_URL;
+
+const server = setupServer(
+  rest.get(`${api}/cafe/1/menus`, (req, res, next) => {
+    return res(
+      next.json({
+        id: 1,
+        cafe_name: 'Cafe name 1',
+        menus: [
+          {
+            id: 1,
+            name: '카페 아메리카노',
+            thumbnail:
+              'https://www.istarbucks.co.kr/upload/store/skuimg/2022/10/[9200000004312]_20221005145029134.jpg',
+            price: 1000,
+          },
+          {
+            id: 2,
+            name: 'Menu name 2',
+            thumbnail: 'Menu Thumbnail',
+            price: 1000,
+          },
+          {
+            id: 3,
+            name: 'Menu name 3',
+            thumbnail: 'Menu Thumbnail',
+            price: 1000,
+          },
+        ],
+      })
+    );
+  })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const setup = ({ url }: { url: string }) => {
+  render(
+    <Layout>
+      <MemoryRouter initialEntries={[url]}>
+        <Router />
+      </MemoryRouter>
+    </Layout>
+  );
+};
+
+describe('MenuList', () => {
+  it('컴포넌트 검사', async () => {
+    setup({ url: '/menu' });
+
+    screen.getByAltText('메뉴 이미지');
+    screen.getByText('카페 아메리카노');
+    screen.getByText('1000');
+  });
+});

--- a/packages/client/src/pages/MenuList/index.spec.tsx
+++ b/packages/client/src/pages/MenuList/index.spec.tsx
@@ -1,0 +1,1 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';

--- a/packages/client/src/pages/MenuList/index.spec.tsx
+++ b/packages/client/src/pages/MenuList/index.spec.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { MemoryRouter } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 import Router from '@/Router';
 import Layout from '@/Layout';
 
@@ -45,11 +46,13 @@ afterAll(() => server.close());
 
 const setup = ({ url }: { url: string }) => {
   render(
-    <Layout>
-      <MemoryRouter initialEntries={[url]}>
-        <Router />
-      </MemoryRouter>
-    </Layout>
+    <RecoilRoot>
+      <Layout>
+        <MemoryRouter initialEntries={[url]}>
+          <Router />
+        </MemoryRouter>
+      </Layout>
+    </RecoilRoot>
   );
 };
 
@@ -57,8 +60,26 @@ describe('MenuList', () => {
   it('컴포넌트 검사', async () => {
     setup({ url: '/menu' });
 
-    screen.getByAltText('메뉴 이미지');
-    screen.getByText('카페 아메리카노');
-    screen.getByText('1000');
+    const menuItems = await screen.findAllByTestId('menu-item');
+    expect(menuItems).toHaveLength(3);
+  });
+
+  it('메뉴 선택시 메뉴 상세 화면으로 전환', async () => {
+    setup({ url: '/menu' });
+
+    const menuItems = await screen.findAllByTestId('menu-item');
+    fireEvent.click(menuItems[0]);
+  });
+
+  it('장바구니 클릭시 장바구니 화면으로 전환', async () => {
+    setup({ url: '/menu' });
+  });
+
+  it('Footer Home 클릭 시 주문내역 화면으로 전환', async () => {
+    setup({ url: '/menu' });
+  });
+
+  it('Footer MY 클릭 시 마이페이지 화면으로 전환', async () => {
+    setup({ url: '/menu' });
   });
 });

--- a/packages/client/src/pages/MenuList/index.tsx
+++ b/packages/client/src/pages/MenuList/index.tsx
@@ -4,6 +4,7 @@ import { CafeMenu } from 'types/MenuList';
 import MenuItem from 'components/MenuItem';
 import Footer from '@/components/Footer';
 import { MenuListPageWrapper, MenuListWrapper } from './styled';
+import SnackBar from '@/components/SnackBar';
 
 function MenuList() {
   const api = process.env.REACT_APP_API_SERVER_BASE_URL;
@@ -37,6 +38,7 @@ function MenuList() {
           />
         ))}
       </MenuListWrapper>
+      <SnackBar />
       <Footer />
     </MenuListPageWrapper>
   );

--- a/packages/client/src/pages/MenuList/index.tsx
+++ b/packages/client/src/pages/MenuList/index.tsx
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { useState, useEffect } from 'react';
+import { CafeMenu } from 'types/MenuList';
+
+function MenuList() {
+  const api = process.env.REACT_APP_API_SERVER_BASE_URL;
+  const [menuList, setMenuList] = useState<CafeMenu>();
+
+  const fetchMenuList = async () => {
+    try {
+      const res = await axios.get(`${api}/cafe/1/menus`, { withCredentials: true });
+      setMenuList(res.data);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchMenuList();
+  }, []);
+
+  return (<div>
+    <ul>
+        {menuList?.menus.map(menu => (
+            <li key={menu.id}>
+                <img src={menu.thumbnail} alt='메뉴 이미지'/>
+                <p>{menu.name}</p>
+                <p>{menu.price}</p>
+            </li>
+        ))}
+    </ul>
+  </div>);
+}
+
+export default MenuList;

--- a/packages/client/src/pages/MenuList/index.tsx
+++ b/packages/client/src/pages/MenuList/index.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { CafeMenu } from 'types/MenuList';
 import MenuItem from 'components/MenuItem';
 import Footer from '@/components/Footer';
+import { MenuListPageWrapper, MenuListWrapper } from './styled';
 
 function MenuList() {
   const api = process.env.REACT_APP_API_SERVER_BASE_URL;
@@ -24,8 +25,8 @@ function MenuList() {
   }, []);
 
   return (
-    <div>
-      <ul>
+    <MenuListPageWrapper>
+      <MenuListWrapper>
         {menuList?.menus.map((menu) => (
           <MenuItem
             key={menu.id}
@@ -35,9 +36,9 @@ function MenuList() {
             price={menu.price}
           />
         ))}
-      </ul>
-      <Footer/>
-    </div>
+      </MenuListWrapper>
+      <Footer />
+    </MenuListPageWrapper>
   );
 }
 

--- a/packages/client/src/pages/MenuList/index.tsx
+++ b/packages/client/src/pages/MenuList/index.tsx
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { useState, useEffect } from 'react';
 import { CafeMenu } from 'types/MenuList';
 import MenuItem from 'components/MenuItem';
+import Footer from '@/components/Footer';
 
 function MenuList() {
   const api = process.env.REACT_APP_API_SERVER_BASE_URL;
@@ -35,6 +36,7 @@ function MenuList() {
           />
         ))}
       </ul>
+      <Footer/>
     </div>
   );
 }

--- a/packages/client/src/pages/MenuList/index.tsx
+++ b/packages/client/src/pages/MenuList/index.tsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { useState, useEffect } from 'react';
 import { CafeMenu } from 'types/MenuList';
+import MenuItem from 'components/MenuItem';
 
 function MenuList() {
   const api = process.env.REACT_APP_API_SERVER_BASE_URL;
@@ -8,7 +9,9 @@ function MenuList() {
 
   const fetchMenuList = async () => {
     try {
-      const res = await axios.get(`${api}/cafe/1/menus`, { withCredentials: true });
+      const res = await axios.get(`${api}/cafe/1/menus`, {
+        withCredentials: true,
+      });
       setMenuList(res.data);
     } catch (err) {
       console.log(err);
@@ -19,17 +22,21 @@ function MenuList() {
     fetchMenuList();
   }, []);
 
-  return (<div>
-    <ul>
-        {menuList?.menus.map(menu => (
-            <li key={menu.id}>
-                <img src={menu.thumbnail} alt='메뉴 이미지'/>
-                <p>{menu.name}</p>
-                <p>{menu.price}</p>
-            </li>
+  return (
+    <div>
+      <ul>
+        {menuList?.menus.map((menu) => (
+          <MenuItem
+            key={menu.id}
+            id={menu.id}
+            name={menu.name}
+            thumbnail={menu.thumbnail}
+            price={menu.price}
+          />
         ))}
-    </ul>
-  </div>);
+      </ul>
+    </div>
+  );
 }
 
 export default MenuList;

--- a/packages/client/src/pages/MenuList/styled.ts
+++ b/packages/client/src/pages/MenuList/styled.ts
@@ -1,0 +1,1 @@
+import styled from '@emotion/styled';

--- a/packages/client/src/pages/MenuList/styled.ts
+++ b/packages/client/src/pages/MenuList/styled.ts
@@ -1,1 +1,9 @@
 import styled from '@emotion/styled';
+
+export const MenuListPageWrapper = styled.div`
+  width: 100%;
+`;
+
+export const MenuListWrapper = styled.ul`
+  margin: 0 2rem 0 2rem;
+`

--- a/packages/client/src/types/MenuList.ts
+++ b/packages/client/src/types/MenuList.ts
@@ -1,0 +1,12 @@
+interface Menu {
+  id: number;
+  name: string;
+  thumbnail: string;
+  price: number;
+}
+
+export interface CafeMenu {
+  id: number;
+  cafe_name: string;
+  menus: Menu[];
+}

--- a/packages/client/src/types/MenuList.ts
+++ b/packages/client/src/types/MenuList.ts
@@ -1,4 +1,4 @@
-interface Menu {
+export interface Menu {
   id: number;
   name: string;
   thumbnail: string;


### PR DESCRIPTION
## 📕 제목
- #67 
- #71 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- Footer 구현
    - [x]  레이아웃 구성
    - [x]  페이지 이동 구현
- 메뉴 리스트 페이지 구현
    - [x]  기본 레이아웃 구성
    - [x]  메뉴 상세 페이지 이동 구현
    - [x]  스낵바 구현
    - [x]  장바구니 페이지 이동 구현
- [x] 테스트 케이스 작성

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 테스트 코드 케이스만 작성해뒀음, 현재 fe에 merge 이후에 내일 작업간 테스트 코드에서 setup 및 Mock 서버 Handler 분리할 필요 있음
