### PR TITLE
메뉴 상세 페이지

### DIFF
--- a/packages/client/src/Router.tsx
+++ b/packages/client/src/Router.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from 'react-router-dom';
 import Signup from './pages/Signup';
 import Signin from './pages/Signin';
 import OrderList from './pages/customer/OrderList';
+import MenuDetail from './pages/customer/MenuDetail';
 
 function Router() {
   return (
@@ -11,8 +12,7 @@ function Router() {
       <Route path={'/mypage'} element={<></>}></Route> {/* 마이페이지 */}
       <Route path={'/home'} element={<OrderList />}></Route> {/* 고객 메인 */}
       <Route path={'/menu'} element={<></>}></Route> {/* 고객 메뉴 목록 */}
-      <Route path={'/menu/:menuId'} element={<></>}></Route>{' '}
-      {/* 고객 메뉴 상세 */}
+      <Route path={'/menu/:menuId'} element={<MenuDetail />}></Route>
       <Route path={'/cart'} element={<></>}></Route> {/* 고객 장바구니 */}
       {/* 업주 (전역 상태 관리로 고객과 함께 사용 가능) */}
       <Route path={'/owner/home'} element={<></>}></Route>

--- a/packages/client/src/components/OptionSelector/index.tsx
+++ b/packages/client/src/components/OptionSelector/index.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import {
+  CategoryContainer,
+  CategoryTitle,
+  Container,
+  OptionItemContainer,
+  OptionsContainer,
+  Title,
+} from './styled';
+
+import { Category, Option } from 'types/MenuDetail';
+
+interface OnClickInputProps {
+  onClick: (event: React.MouseEvent<HTMLInputElement>) => void;
+}
+
+interface Props extends OnClickInputProps {
+  options: Option[];
+}
+
+interface CategoryItemProps extends OnClickInputProps {
+  category: string;
+  options: Option[];
+}
+
+interface OptionItemProps extends OnClickInputProps {
+  option: Option;
+}
+
+/**
+ * 하나의 옵션 아이템 컴포넌트
+ */
+function OptionItem({ option, onClick }: OptionItemProps) {
+  return (
+    <OptionItemContainer>
+      <p>{option.name}</p>
+      <div>
+        <p>{option.price} 원</p>
+        <label>
+          <input
+            type="radio"
+            value={option.id}
+            name={option.category}
+            onClick={onClick}
+          />
+        </label>
+      </div>
+    </OptionItemContainer>
+  );
+}
+
+/**
+ * 하나의 카테고리 아이템 컴포넌트, 옵션들 모음 컴포넌트
+ */
+function CategoryItem({ category, options, onClick }: CategoryItemProps) {
+  return (
+    <CategoryContainer>
+      <CategoryTitle>{category}</CategoryTitle>
+      <OptionsContainer>
+        {options.map((option, idx) => (
+          <OptionItem option={option} onClick={onClick} key={option.id} />
+        ))}
+      </OptionsContainer>
+    </CategoryContainer>
+  );
+}
+
+/**
+ * 카테고리 리스트 컴포넌트
+ *
+ * (옵션들의 카테고리 모음 컴포넌트)
+ */
+function OptionSelector({ options, onClick }: Props) {
+  const [categoryGroups, setCategoryGrops] = useState<Category>({});
+
+  // 옵션 목록을 카테고리별로 분리
+  useEffect(() => {
+    const groups = options.reduce((prev: Category, curr) => {
+      const category = curr.category as string;
+
+      if (Object.keys(prev).includes(category)) {
+        return { ...prev, [category]: [...prev[category], { ...curr }] };
+      } else {
+        return { ...prev, [category]: [{ ...curr }] };
+      }
+    }, {});
+
+    setCategoryGrops(groups);
+  }, [options]);
+
+  return (
+    <Container>
+      <Title>퍼스널 옵션</Title>
+      {Object.keys(categoryGroups).map((c) => (
+        <CategoryItem
+          category={c}
+          options={categoryGroups[c]}
+          key={c}
+          onClick={onClick}
+        />
+      ))}
+    </Container>
+  );
+}
+
+export default OptionSelector;

--- a/packages/client/src/components/OptionSelector/styled.ts
+++ b/packages/client/src/components/OptionSelector/styled.ts
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.section`
+  margin: 5%;
+`;
+
+export const Title = styled.p`
+  font-size: ${(props) => props.theme.font.size.lg};
+`;
+
+export const CategoryContainer = styled.div`
+  margin: 5% 0;
+`;
+
+export const CategoryTitle = styled.p`
+  font-size: ${(props) => props.theme.font.size.md};
+`;
+
+export const OptionsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin: 5% 0;
+`;
+
+export const OptionItemContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  & > div {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+  }
+
+  & > div > label {
+    margin: 5% 0;
+  }
+`;

--- a/packages/client/src/components/SizeSelector/__snapshots__/index.test.tsx.snap
+++ b/packages/client/src/components/SizeSelector/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`음료 용량 선택 컴포넌트 스냅샷 1`] = `
+<DocumentFragment>
+  <main
+    class="css-22d8cp"
+  >
+    <section
+      class="css-r3ushx"
+    >
+      <div
+        class="css-ev3gks"
+        title="tall"
+      >
+        <p>
+          icon
+        </p>
+        <p
+          class="css-ktof6v"
+        >
+          tall
+        </p>
+        <p
+          class="css-11bhzdh"
+        >
+          355ml
+        </p>
+      </div>
+      <div
+        class="css-1c2d3af"
+        title="grande"
+      >
+        <p>
+          icon
+        </p>
+        <p
+          class="css-ktof6v"
+        >
+          grande
+        </p>
+        <p
+          class="css-11bhzdh"
+        >
+          473ml
+        </p>
+      </div>
+      <div
+        class="css-1c2d3af"
+        title="venti"
+      >
+        <p>
+          icon
+        </p>
+        <p
+          class="css-ktof6v"
+        >
+          venti
+        </p>
+        <p
+          class="css-11bhzdh"
+        >
+          591ml
+        </p>
+      </div>
+    </section>
+  </main>
+</DocumentFragment>
+`;

--- a/packages/client/src/components/SizeSelector/index.test.tsx
+++ b/packages/client/src/components/SizeSelector/index.test.tsx
@@ -1,0 +1,58 @@
+import Layout from '@/Layout';
+import { Size } from '@/types/MenuDetail';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SizeSelector from '.';
+
+interface Setup {
+  size: Size;
+}
+
+const setup = ({ size }: Setup) => {
+  const handleClickSize = jest.fn();
+  const { asFragment } = render(
+    <Layout>
+      <SizeSelector size={size} onClick={handleClickSize} />
+    </Layout>
+  );
+
+  return { asFragment, handleClickSize };
+};
+
+describe('음료 용량 선택 컴포넌트', () => {
+  it('요소 존재 여부', () => {
+    setup({ size: 'tall' });
+
+    screen.getByTitle(/tall/);
+    screen.getByTitle(/grande/);
+    screen.getByTitle(/venti/);
+  });
+
+  it('tall 선택됨', () => {
+    setup({ size: 'tall' });
+
+    const btnTall = screen.getByTitle(/tall/);
+    expect(btnTall).toHaveStyle('border-color: #567F72');
+  });
+
+  it('grande 선택됨', () => {
+    setup({ size: 'grande' });
+
+    const btnGrande = screen.getByTitle(/grande/);
+    expect(btnGrande).toHaveStyle('border-color: #567F72');
+  });
+
+  it('용량 변경 함수 실행', () => {
+    const { handleClickSize } = setup({ size: 'tall' });
+
+    const btnGrande = screen.getByTitle(/grande/);
+    fireEvent.click(btnGrande);
+
+    expect(handleClickSize).toBeCalled();
+  });
+
+  it('스냅샷', () => {
+    const { asFragment } = setup({ size: 'tall' });
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/client/src/components/SizeSelector/index.tsx
+++ b/packages/client/src/components/SizeSelector/index.tsx
@@ -1,0 +1,43 @@
+import React, { useMemo } from 'react';
+import { Container, ItemContainer, SizeText, VolumeText } from './styled';
+import { SIZE_VOLUME } from '@/constants';
+import { Size } from 'types/MenuDetail';
+
+interface Props {
+  size: Size;
+  onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+interface ItemProps extends Props {
+  isSelected: boolean;
+}
+
+// 음료 사이즈 선택 아이템 컴포넌트
+function Item({ size, isSelected, onClick }: ItemProps) {
+  const sizeText = useMemo(() => <SizeText>{size}</SizeText>, [size]);
+  const volumeText = useMemo(
+    () => <VolumeText>{SIZE_VOLUME[size]}ml</VolumeText>,
+    [size]
+  );
+
+  return (
+    <ItemContainer title={size} isSelected={isSelected} onClick={onClick}>
+      <p>icon</p>
+      {sizeText}
+      {volumeText}
+    </ItemContainer>
+  );
+}
+
+// 음료 사이즈 선택 컴포넌트
+function SizeSelector({ size, onClick }: Props) {
+  const sizes: Size[] = ['tall', 'grande', 'venti'];
+
+  const items = sizes.map((s) => (
+    <Item size={s} isSelected={size === s} onClick={onClick} key={s} />
+  ));
+
+  return <Container>{items}</Container>;
+}
+
+export default SizeSelector;

--- a/packages/client/src/components/SizeSelector/styled.ts
+++ b/packages/client/src/components/SizeSelector/styled.ts
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.section`
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  margin: 5%;
+`;
+
+export const ItemContainer = styled.div<{ isSelected: boolean }>`
+  width: 28%;
+  padding: 5%;
+  border-radius: 10px;
+  text-align: center;
+  border: ${(props) => props.theme.border.default};
+  border-width: 2px;
+  border-color: ${(props) =>
+    props.isSelected ? props.theme.colors.primary : props.theme.colors.grey200};
+`;
+
+export const SizeText = styled.p`
+  margin: 10% 0;
+  font-size: ${(props) => props.theme.font.size.md};
+`;
+
+export const VolumeText = styled.p`
+  font-size: ${(props) => props.theme.font.size.xs};
+  color: ${(props) => props.theme.colors.grey600};
+`;

--- a/packages/client/src/components/TypeSelector/__snapshots__/index.test.tsx.snap
+++ b/packages/client/src/components/TypeSelector/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`음료 타입(핫, 아이스) 선택 컴포넌트 스냅샷 1`] = `
+<DocumentFragment>
+  <main
+    class="css-22d8cp"
+  >
+    <section
+      class="css-6mixyn"
+    >
+      <span
+        class="hot"
+      >
+        HOT
+      </span>
+      <span
+        class="iced"
+      >
+        ICED
+      </span>
+    </section>
+  </main>
+</DocumentFragment>
+`;

--- a/packages/client/src/components/TypeSelector/index.test.tsx
+++ b/packages/client/src/components/TypeSelector/index.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import TypeSelector from '.';
+import Layout from '@/Layout';
+import { Type } from '@/types/MenuDetail';
+
+const setup = ({ type }: { type: Type }) => {
+  const handleClickType = jest.fn();
+  const { asFragment } = render(
+    <Layout>
+      <TypeSelector type={type} onClick={handleClickType} />
+    </Layout>
+  );
+
+  return { asFragment, handleClickType };
+};
+
+describe('음료 타입(핫, 아이스) 선택 컴포넌트', () => {
+  it('요소 존재 여부', () => {
+    setup({ type: 'hot' });
+
+    screen.getByText(/hot/i);
+    screen.getByText(/iced/i);
+  });
+
+  it('HOT 선택됨', () => {
+    setup({ type: 'hot' });
+
+    const btnHot = screen.getByText(/hot/i);
+    expect(btnHot).toHaveStyle('background-color: red;');
+  });
+
+  it('ICED 선택됨', () => {
+    setup({ type: 'iced' });
+
+    const btnIced = screen.getByText(/iced/i);
+
+    expect(btnIced).toHaveStyle('background-color: blue;');
+  });
+
+  it('타입 변경 함수 실행', () => {
+    const { handleClickType } = setup({ type: 'hot' });
+
+    const btnIced = screen.getByText(/iced/i);
+    fireEvent.click(btnIced);
+
+    expect(handleClickType).toBeCalled();
+  });
+
+  it('스냅샷', () => {
+    const { asFragment } = setup({ type: 'hot' });
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/client/src/components/TypeSelector/index.tsx
+++ b/packages/client/src/components/TypeSelector/index.tsx
@@ -1,0 +1,23 @@
+import { Container } from './styled';
+import { Type } from 'types/MenuDetail';
+import { memo } from 'react';
+
+interface Props {
+  type: Type;
+  onClick: (event: React.MouseEvent<HTMLSpanElement>) => void;
+}
+
+function TypeSelector({ type, onClick }: Props) {
+  return (
+    <Container selected={type}>
+      <span className="hot" onClick={onClick}>
+        HOT
+      </span>
+      <span className="iced" onClick={onClick}>
+        ICED
+      </span>
+    </Container>
+  );
+}
+
+export default memo(TypeSelector);

--- a/packages/client/src/components/TypeSelector/styled.ts
+++ b/packages/client/src/components/TypeSelector/styled.ts
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.section<{ selected: string }>`
+  margin: 10% 5%;
+  display: flex;
+  justify-content: center;
+
+  & > span {
+    padding: 5px;
+    width: 50%;
+    text-align: center;
+    color: white;
+  }
+
+  & > .hot {
+    border-top-left-radius: 100px;
+    border-bottom-left-radius: 100px;
+    border: ${(props) => props.theme.border.default};
+    border-color: ${(props) => props.theme.colors.grey200};
+    background-color: ${(props) => (props.selected === 'hot' ? 'red' : '')};
+    color: ${(props) =>
+      props.selected === 'hot' ? 'white' : props.theme.colors.grey600};
+  }
+
+  & > .iced {
+    border-top-right-radius: 100px;
+    border-bottom-right-radius: 100px;
+    border: ${(props) => props.theme.border.default};
+    border-color: ${(props) => props.theme.colors.grey200};
+    background-color: ${(props) => (props.selected === 'iced' ? 'blue' : '')};
+    color: ${(props) =>
+      props.selected === 'iced' ? 'white' : props.theme.colors.grey600};
+  }
+`;

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -2,3 +2,9 @@ export const PLACEHOLDER = {
   nickname: '닉네임을 입력해주세요. 알파벳, 숫자만 사용',
   corporate: '사업자 등록 번호를 입력해주세요.',
 };
+
+export const SIZE_VOLUME = {
+  tall: 355,
+  grande: 473,
+  venti: 591,
+};

--- a/packages/client/src/pages/Signin/index.tsx
+++ b/packages/client/src/pages/Signin/index.tsx
@@ -1,7 +1,6 @@
 import axios, { AxiosError } from 'axios';
 import { useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import axios, { AxiosError } from 'axios';
 
 import { chkUser } from 'types/Signin';
 import { Container, Logo, NaverOAuth } from './styled';

--- a/packages/client/src/pages/customer/MenuDetail/index.tsx
+++ b/packages/client/src/pages/customer/MenuDetail/index.tsx
@@ -1,0 +1,5 @@
+function MenuDetail() {
+  return <></>;
+}
+
+export default MenuDetail;

--- a/packages/client/src/pages/customer/MenuDetail/index.tsx
+++ b/packages/client/src/pages/customer/MenuDetail/index.tsx
@@ -6,33 +6,16 @@ import TypeSelector from 'components/TypeSelector';
 import SizeSelector from 'components/SizeSelector';
 
 import { BackArrow, Container, Img, MenuInfoContainer } from './styled';
-import { MenuInfo, Size, Type } from 'types/MenuDetail';
+import { MenuInfo, Options, Size, Type } from 'types/MenuDetail';
+import OptionSelector from '@/components/OptionSelector';
 
 function MenuDetail() {
   const api = process.env.REACT_APP_API_SERVER_BASE_URL;
   const [menu, setMenu] = useState<MenuInfo | null | undefined>(null);
   const [type, setType] = useState<Type>('hot');
   const [size, setSize] = useState<Size>('tall');
+  const [options, setOptions] = useState<Options>({});
   const { menuId } = useParams();
-
-  /**
-   * 초기 메뉴 상세 정보 조회
-   */
-  useEffect(() => {
-    if (!api || !menuId) return;
-
-    const getMenuInfo = async () => {
-      try {
-        const res = await axios.get(`${api}/cafe/menu/${menuId}`);
-        setMenu(res.data);
-      } catch (err) {
-        alert('메뉴 상세 조회 실패 다시 시도해주세요.');
-        setMenu(undefined);
-      }
-    };
-
-    getMenuInfo();
-  }, [api, menuId]);
 
   /**
    * 음료 타입(핫, 아이스) 선택에 따라 음료 타입 변경
@@ -58,6 +41,48 @@ function MenuDetail() {
       return;
     setSize(newSize);
   };
+
+  /**
+   * 주문하기 버튼 클릭에 따른 장바구니 추가
+   */
+  const handleClickOrder = (event: React.MouseEvent<HTMLButtonElement>) => {};
+
+  /**
+   * 카테고리별 옵션 선택에 따라 옵션 변경
+   */
+  const handleClickOption = (event: React.MouseEvent<HTMLInputElement>) => {
+    const category = event.currentTarget.name;
+    const currOption = event.currentTarget.value;
+
+    if (Object.keys(options).includes(category)) {
+      const prevOption = options[category];
+
+      if (prevOption === currOption) {
+        event.currentTarget.checked = false;
+        return setOptions({ ...options, [category]: undefined });
+      }
+    }
+    return setOptions({ ...options, [category]: currOption });
+  };
+
+  /**
+   * 초기 메뉴 상세 정보 조회
+   */
+  useEffect(() => {
+    if (!api || !menuId) return;
+
+    const getMenuInfo = async () => {
+      try {
+        const res = await axios.get(`${api}/cafe/menu/${menuId}`);
+        setMenu(res.data);
+      } catch (err) {
+        alert('메뉴 상세 조회 실패 다시 시도해주세요.');
+        setMenu(undefined);
+      }
+    };
+
+    getMenuInfo();
+  }, [api, menuId]);
 
   /**
    * 메뉴 정보 렌더링 (Memorize)
@@ -89,6 +114,15 @@ function MenuDetail() {
           {MenuInfo}
           <TypeSelector type={type} onClick={handleClickType} />
           <SizeSelector size={size} onClick={handleClickSize} />
+          {menu.options.length > 0 && (
+            <OptionSelector
+              onClick={handleClickOption}
+              options={menu.options}
+            />
+          )}
+          <button type="button" onClick={handleClickOrder}>
+            주문하기
+          </button>
         </>
       )}
     </Container>

--- a/packages/client/src/pages/customer/MenuDetail/index.tsx
+++ b/packages/client/src/pages/customer/MenuDetail/index.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import axios from 'axios';
-import {
-  BackArrow,
-  Container,
-  Img,
-  MenuInfoContainer,
-} from './styled';
+
+import TypeSelector from 'components/TypeSelector';
+import SizeSelector from 'components/SizeSelector';
+
+import { BackArrow, Container, Img, MenuInfoContainer } from './styled';
 import { MenuInfo, Size, Type } from 'types/MenuDetail';
 
 function MenuDetail() {
@@ -36,6 +35,31 @@ function MenuDetail() {
   }, [api, menuId]);
 
   /**
+   * 음료 타입(핫, 아이스) 선택에 따라 음료 타입 변경
+   *
+   * @param event 클릭 이벤트
+   */
+  const handleClickType = (event: React.MouseEvent<HTMLSpanElement>) => {
+    const newType = event.currentTarget.className;
+
+    if (newType !== 'hot' && newType !== 'iced') return;
+    setType(newType);
+  };
+
+  /**
+   * 음료 용량 선택에 따라 용량 변경
+   *
+   * @param event 클릭 이벤트
+   */
+  const handleClickSize = (event: React.MouseEvent<HTMLDivElement>) => {
+    const newSize = event.currentTarget.title;
+
+    if (newSize !== 'tall' && newSize !== 'grande' && newSize !== 'venti')
+      return;
+    setSize(newSize);
+  };
+
+  /**
    * 메뉴 정보 렌더링 (Memorize)
    */
   const MenuInfo = useMemo(() => {
@@ -63,6 +87,8 @@ function MenuDetail() {
         <>
           <BackArrow>{'<'}</BackArrow>
           {MenuInfo}
+          <TypeSelector type={type} onClick={handleClickType} />
+          <SizeSelector size={size} onClick={handleClickSize} />
         </>
       )}
     </Container>

--- a/packages/client/src/pages/customer/MenuDetail/index.tsx
+++ b/packages/client/src/pages/customer/MenuDetail/index.tsx
@@ -1,5 +1,72 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import axios from 'axios';
+import {
+  BackArrow,
+  Container,
+  Img,
+  MenuInfoContainer,
+} from './styled';
+import { MenuInfo, Size, Type } from 'types/MenuDetail';
+
 function MenuDetail() {
-  return <></>;
+  const api = process.env.REACT_APP_API_SERVER_BASE_URL;
+  const [menu, setMenu] = useState<MenuInfo | null | undefined>(null);
+  const [type, setType] = useState<Type>('hot');
+  const [size, setSize] = useState<Size>('tall');
+  const { menuId } = useParams();
+
+  /**
+   * 초기 메뉴 상세 정보 조회
+   */
+  useEffect(() => {
+    if (!api || !menuId) return;
+
+    const getMenuInfo = async () => {
+      try {
+        const res = await axios.get(`${api}/cafe/menu/${menuId}`);
+        setMenu(res.data);
+      } catch (err) {
+        alert('메뉴 상세 조회 실패 다시 시도해주세요.');
+        setMenu(undefined);
+      }
+    };
+
+    getMenuInfo();
+  }, [api, menuId]);
+
+  /**
+   * 메뉴 정보 렌더링 (Memorize)
+   */
+  const MenuInfo = useMemo(() => {
+    if (!menu) return;
+
+    return (
+      <>
+        <Img src="https://www.istarbucks.co.kr/upload/store/skuimg/2022/10/[9200000004312]_20221005145029134.jpg" />
+        <MenuInfoContainer>
+          <h2>{menu.name}</h2>
+          <p className="description">{menu.thumbnail}</p>
+          <p className="price">{menu.price}원</p>
+        </MenuInfoContainer>
+      </>
+    );
+  }, [menu]);
+
+  return (
+    <Container>
+      {menu === null ? (
+        <p>Loading...</p>
+      ) : menu === undefined ? (
+        <p>데이터 조회 오류</p>
+      ) : (
+        <>
+          <BackArrow>{'<'}</BackArrow>
+          {MenuInfo}
+        </>
+      )}
+    </Container>
+  );
 }
 
 export default MenuDetail;

--- a/packages/client/src/pages/customer/MenuDetail/styled.ts
+++ b/packages/client/src/pages/customer/MenuDetail/styled.ts
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.main`
+  width: 100%;
+`;
+
+export const BackArrow = styled.i`
+  position: absolute;
+  top: 2%;
+  left: 2%;
+  color: ${(props) => props.theme.colors.grey600};
+`;
+
+export const Img = styled.img`
+  width: 100%;
+  object-fit: cover;
+`;
+
+export const MenuInfoContainer = styled.section`
+  margin: 10% 5%;
+
+  & > h2,
+  & > .price {
+    font-size: ${(props) => props.theme.font.size.lg};
+  }
+
+  & > .description {
+    margin: 15px 0;
+    color: ${(props) => props.theme.colors.grey600};
+  }
+`;

--- a/packages/client/src/types/MenuDetail.ts
+++ b/packages/client/src/types/MenuDetail.ts
@@ -1,0 +1,25 @@
+export interface MenuInfo {
+  id: number;
+  name: string;
+  description: string;
+  price: number;
+  thumbnail: string;
+  options: Option[];
+}
+
+export interface Category {
+  [key: string]: Option[];
+}
+
+export interface Option {
+  id: number;
+  name: string;
+  price: number;
+  category: string;
+}
+
+export type Type = 'hot' | 'iced';
+export type Size = 'tall' | 'grande' | 'venti';
+export interface Options {
+  [key: string]: string | undefined;
+}


### PR DESCRIPTION
## 📕 메뉴 상세 페이지
- #69 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 메뉴 상세페이지 라우트
- [x] 메뉴 상세 조회
- [x] 음료 타입(핫, 아이스) 선택 컴포넌트 추가
  - [x] 테스트 작성
- [x] 음료 용량 선택 컴포넌트 추가
  - [x] 테스트 작성
- [x] 음료 옵션 선택 컴포넌트 추가

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 음료 옵션 선택 컴포넌트 테스트 작성 필요
- 메뉴 상세 페이지 전체 통합테스트 작성 필요
- 컴포넌트 파일 분리에 대해 의논 필요
- 메뉴 상세 조회 페이지도 전역 상태 관리 고려해볼 필요 있음
  - 최대 3개 아래 컴포넌트까지 Props Drilling 발생
  - 최상단 페이지 파일에 상태 관리를 위한 로직이 많이 필요하여 코드가 꽤 길어짐