### PR TITLE
메뉴 리스트 페이지 스타일 적용 및 버튼 컴포넌트 분리

### DIFF
--- a/packages/client/src/components/Button/index.tsx
+++ b/packages/client/src/components/Button/index.tsx
@@ -1,0 +1,13 @@
+import { MouseEventHandler, ReactNode } from 'react';
+import { CustomButton } from './styled';
+
+interface ButtonProps {
+  onClick?: MouseEventHandler;
+  children?: ReactNode | ReactNode[];
+}
+
+function Button({ onClick, children }: ButtonProps) {
+  return <CustomButton onClick={onClick}>{children}</CustomButton>;
+}
+
+export default Button;

--- a/packages/client/src/components/Button/styled.ts
+++ b/packages/client/src/components/Button/styled.ts
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+
+export const CustomButton = styled.button`
+  width: 80%;
+  padding: 0.3rem 0 0.3rem 0;
+  background-color: ${(props) => props.theme.colors.primary};
+  color: white;
+  font-size: ${(props) => props.theme.font.size.xs};
+  font-weight: ${(props) => props.theme.font.weight.bold700};
+  border: none;
+  border-radius: 50px;
+`;

--- a/packages/client/src/components/Footer/styled.ts
+++ b/packages/client/src/components/Footer/styled.ts
@@ -6,6 +6,7 @@ export const FooterWrapper = styled.footer`
   bottom: 0;
   width: 100%;
   height: 3rem;
+  background-color: white;
   box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5),
     0px 0px 4px rgba(0, 0, 0, 0.25);
 `;

--- a/packages/client/src/components/MenuItem/index.tsx
+++ b/packages/client/src/components/MenuItem/index.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { Menu } from '@/types/MenuList';
 import { MenuImg, MenuWrapper, MenuInfoWrapper } from './styled';
-import { formatNumber } from 'utils/util';
 
 function MenuItem(props: Menu) {
   const navigate = useNavigate();
@@ -19,7 +18,7 @@ function MenuItem(props: Menu) {
       <MenuImg src={props.thumbnail} alt="메뉴 이미지" />
       <MenuInfoWrapper>
         <p>{props.name}</p>
-        <p>{formatNumber(props.price)}원</p>
+        <p>{props.price}원</p>
       </MenuInfoWrapper>
     </MenuWrapper>
   );

--- a/packages/client/src/components/MenuItem/index.tsx
+++ b/packages/client/src/components/MenuItem/index.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { Menu } from '@/types/MenuList';
 import { MenuImg, MenuWrapper, MenuInfoWrapper } from './styled';
+import { formatNumber } from 'utils/util';
 
 function MenuItem(props: Menu) {
   const navigate = useNavigate();
@@ -10,11 +11,15 @@ function MenuItem(props: Menu) {
   };
 
   return (
-    <MenuWrapper key={props.id} onClick={handleClickMenuItem} data-testid={'menu-item'}>
+    <MenuWrapper
+      key={props.id}
+      onClick={handleClickMenuItem}
+      data-testid={'menu-item'}
+    >
       <MenuImg src={props.thumbnail} alt="메뉴 이미지" />
       <MenuInfoWrapper>
         <p>{props.name}</p>
-        <p>{props.price}</p>
+        <p>{formatNumber(props.price)}원</p>
       </MenuInfoWrapper>
     </MenuWrapper>
   );

--- a/packages/client/src/components/MenuItem/styled.ts
+++ b/packages/client/src/components/MenuItem/styled.ts
@@ -17,5 +17,6 @@ export const MenuInfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 0.3rem;
+  gap: 0.5rem;
+  font-size: ${(props) => props.theme.font.size.sm}
 `

--- a/packages/client/src/components/SnackBar/styled.ts
+++ b/packages/client/src/components/SnackBar/styled.ts
@@ -12,5 +12,6 @@ export const SnackBarWrapper = styled.div`
   padding: 0 1rem 0 1rem;
   background-color: ${(props) => props.theme.colors.secondary};
   color: white;
+  font-size: ${(props) => props.theme.font.size.sm};
   font-weight: ${(props) => props.theme.font.weight.bold500};
 `;

--- a/packages/client/src/pages/MenuList/styled.ts
+++ b/packages/client/src/pages/MenuList/styled.ts
@@ -5,5 +5,5 @@ export const MenuListPageWrapper = styled.div`
 `;
 
 export const MenuListWrapper = styled.ul`
-  margin: 0 2rem 0 2rem;
+  margin: 0 2rem 6.5rem 2rem;
 `

--- a/packages/client/src/pages/Signup/index.tsx
+++ b/packages/client/src/pages/Signup/index.tsx
@@ -9,9 +9,9 @@ import {
   InputWrapper,
   InputTitle,
   Input,
-  CustomButton,
 } from './styled';
 import { SignupRequestBody } from 'types/Signup';
+import Button from 'components/Button';
 
 function Signup() {
   const api = process.env.REACT_APP_API_SERVER_BASE_URL;
@@ -126,7 +126,7 @@ function Signup() {
       ) : (
         <></>
       )}
-      <CustomButton onClick={handleSubmit}>회원가입</CustomButton>
+      <Button onClick={handleSubmit}>회원가입</Button>
     </PageWrapper>
   );
 }

--- a/packages/client/src/pages/Signup/styled.ts
+++ b/packages/client/src/pages/Signup/styled.ts
@@ -50,14 +50,3 @@ export const Input = styled.input`
     outline: none;
   }
 `;
-
-export const CustomButton = styled.button`
-  width: 80%;
-  padding: 0.3rem 0 0.3rem 0;
-  background-color: ${(props) => props.theme.colors.primary};
-  color: white;
-  font-size: ${(props) => props.theme.font.size.xs};
-  font-weight: ${(props) => props.theme.font.weight.bold700};
-  border: none;
-  border-radius: 50px;
-`;

--- a/packages/client/src/utils/util.ts
+++ b/packages/client/src/utils/util.ts
@@ -1,0 +1,3 @@
+export const formatNumber = (number: number) => {
+  return number.toLocaleString('ko-KR');
+};

--- a/packages/client/src/utils/util.ts
+++ b/packages/client/src/utils/util.ts
@@ -1,3 +1,0 @@
-export const formatNumber = (number: number) => {
-  return number.toLocaleString('ko-KR');
-};


### PR DESCRIPTION
## 📕 제목
- #67 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 메뉴 리스트 스타일 수정
- [x] 버튼 컴포넌트 분리

## 📘 PR 특이 사항

- 버튼 컴포넌트 분리 했고, props로 onClick과 children 넘겨줄 수 있도록 함. 안넘길 수도 있기 때문에 ? 붙여뒀음
