### PR TITLE
카페 entity 수정, 메뉴(+상세정보) 조회 테스트 코드 작성

### DIFF
--- a/packages/server/src/cafe/cafe.service.spec.ts
+++ b/packages/server/src/cafe/cafe.service.spec.ts
@@ -1,0 +1,92 @@
+import { Menu } from 'src/cafe/entities/menu.entity';
+import { CafeService } from './cafe.service';
+import { Cafe } from './entities/cafe.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BadRequestException } from '@nestjs/common';
+
+const mockCafeRepository = () => ({
+  findOne: jest.fn(),
+});
+
+const mockMenuRepository = () => ({
+  findOne: jest.fn(),
+});
+
+type MockRepository<T = any> = Partial<Record<keyof Repository<T>, jest.Mock>>;
+
+describe('CafeService', () => {
+  let service: CafeService;
+  let cafeRepository: MockRepository<Cafe>;
+  let menuRepository: MockRepository<Menu>;
+
+  beforeEach(async () => {
+    //testmodule에서 기존에 provider에 의존성을 주입하는 것처럼
+    // 의존성 있는 모든 provider에 mocking provider 주입해야됨
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CafeService,
+        {
+          provide: getRepositoryToken(Cafe),
+          useValue: mockCafeRepository(),
+        },
+        {
+          provide: getRepositoryToken(Menu),
+          useValue: mockMenuRepository(),
+        },
+      ],
+    }).compile();
+
+    service = module.get<CafeService>(CafeService);
+    cafeRepository = module.get<MockRepository<Cafe>>(getRepositoryToken(Cafe));
+    menuRepository = module.get<MockRepository<Cafe>>(getRepositoryToken(Cafe));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('CafeService', () => {
+    describe('findAll()', () => {
+      const cafeId = 1;
+
+      it('should be find All', async () => {
+        const mockData = {
+          id: 1,
+          name: 'Cafe name 1',
+          cafeMenus: [
+            {
+              menu: {
+                id: 1,
+                name: '민트 콜드 브루',
+                thumbnail:
+                  'https://www.istarbucks.co.kr/upload/store/skuimg/2022/10/[9200000004312]_20221005145029134.jpg',
+                price: 4000,
+                category: '콜드 브루',
+              },
+            },
+            {
+              menu: {
+                id: 2,
+                name: '오트 크림 스카치 콜드 브루',
+                thumbnail:
+                  'https://www.istarbucks.co.kr/upload/store/skuimg/2022/10/[9200000004279]_20221017113059439.jpg',
+                price: 6000,
+                category: '콜드 브루',
+              },
+            },
+          ],
+        };
+        cafeRepository.findOne.mockResolvedValue(mockData);
+
+        const result = await service.findAllMenuById(cafeId);
+
+        expect(cafeRepository.findOne).toHaveBeenCalledTimes(1);
+
+        expect(result.id).toEqual(mockData.id);
+        expect(result.menus.length).toEqual(mockData.cafeMenus.length);
+      });
+    });
+  });
+});

--- a/packages/server/src/cafe/cafe.service.spec.ts
+++ b/packages/server/src/cafe/cafe.service.spec.ts
@@ -40,7 +40,7 @@ describe('CafeService', () => {
 
     service = module.get<CafeService>(CafeService);
     cafeRepository = module.get<MockRepository<Cafe>>(getRepositoryToken(Cafe));
-    menuRepository = module.get<MockRepository<Cafe>>(getRepositoryToken(Cafe));
+    menuRepository = module.get<MockRepository<Cafe>>(getRepositoryToken(Menu));
   });
 
   it('should be defined', () => {
@@ -110,6 +110,61 @@ describe('CafeService', () => {
         await expect(
           async () => await service.findAllMenuById(cafeId)
         ).rejects.toThrowError(new BadRequestException('cafeId not exist'));
+      });
+    });
+    describe('findOneMenuDetail()', () => {
+      it('should be findOneMenuDetail', async () => {
+        // given
+        const mockData = {
+          id: 1,
+          name: '민트 콜드 브루',
+          description:
+            '상쾌한 민트향 시럽과 잘게 갈린 얼음이 \n어우러져 시원함이 강렬하게 느껴지는 리저브만의\n콜드 브루 음료',
+          price: 4000,
+          category: '콜드 브루',
+          thumbnail:
+            'https://www.istarbucks.co.kr/upload/store/skuimg/2022/10/[9200000004312]_20221005145029134.jpg',
+          menuOptions: [
+            {
+              id: 1,
+              option: {
+                id: 1,
+                name: '에스프레스 샷 추가',
+                price: 600,
+                category: '커피',
+              },
+            },
+            {
+              id: 2,
+              option: {
+                id: 2,
+                name: '바닐라 시럽',
+                price: 600,
+                category: '시럽',
+              },
+            },
+          ],
+        };
+        const menuId = 1;
+        menuRepository.findOne.mockResolvedValue(mockData);
+
+        // when
+        const result = await service.findOneMenuDetail(menuId);
+
+        // then
+        expect(menuRepository.findOne).toHaveBeenCalledTimes(1);
+        expect(result.id).toEqual(mockData.id);
+      });
+
+      it('검색은 성공했지만 해당 menu가 없는 경우', async () => {
+        // given
+        const menuId = 1000000;
+        menuRepository.findOne.mockResolvedValue(null);
+
+        // when, then
+        await expect(
+          async () => await service.findOneMenuDetail(menuId)
+        ).rejects.toThrowError(new BadRequestException('menuId not exist'));
       });
     });
   });

--- a/packages/server/src/cafe/cafe.service.ts
+++ b/packages/server/src/cafe/cafe.service.ts
@@ -31,7 +31,7 @@ export class CafeService {
   }
 
   async findOneMenuDetail(menuId: number): Promise<MenuDetailResDto> {
-    const menus = await this.menuRepository.findOne({
+    const menu = await this.menuRepository.findOne({
       where: {
         id: menuId,
       },
@@ -42,6 +42,7 @@ export class CafeService {
       },
     });
 
-    return new MenuDetailResDto(menus);
+    if (menu === null) throw new BadRequestException('menuId not exist');
+    return new MenuDetailResDto(menu);
   }
 }

--- a/packages/server/src/cafe/cafe.service.ts
+++ b/packages/server/src/cafe/cafe.service.ts
@@ -40,8 +40,6 @@ export class CafeService {
         },
       },
     });
-    console.log(menus);
-    console.log(menus.menuOptions);
 
     return new MenuDetailResDto(menus);
   }

--- a/packages/server/src/cafe/cafe.service.ts
+++ b/packages/server/src/cafe/cafe.service.ts
@@ -1,6 +1,6 @@
 import { CafeMenu } from './entities/cafeMenu.entity';
 import { Menu } from './entities/menu.entity';
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Cafe } from './entities/cafe.entity';
@@ -26,6 +26,7 @@ export class CafeService {
       },
     });
 
+    if (cafe === null) throw new BadRequestException('cafeId not exist');
     return new CafeMenuResDto(cafe);
   }
 

--- a/packages/server/src/cafe/dto/CafeMenuRes.dto.ts
+++ b/packages/server/src/cafe/dto/CafeMenuRes.dto.ts
@@ -4,12 +4,12 @@ import { MenuDto } from './MenuRes.dto';
 
 export class CafeMenuResDto {
   @Exclude() private readonly _id: number;
-  @Exclude() readonly _cafe_name: string;
+  @Exclude() readonly _name: string;
   @Exclude() readonly _menus: MenuDto[];
 
   constructor(cafe: Cafe) {
     this._id = cafe.id;
-    this._cafe_name = cafe.name;
+    this._name = cafe.name;
     this._menus = cafe.cafeMenus.map((cafeMenu) => MenuDto.from(cafeMenu.menu));
   }
 
@@ -19,8 +19,8 @@ export class CafeMenuResDto {
   }
 
   @Expose()
-  get cafe_name(): string {
-    return this._cafe_name;
+  get name(): string {
+    return this._name;
   }
 
   @Expose()


### PR DESCRIPTION
## 📕 카페 entity 수정, 메뉴(+상세정보) 조회 테스트 코드 작성
-  #70

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 카페 entity column 중 cafe_name -> name으로 수정
- [x] 카페의 모든 메뉴 조희 API
  - [x] 카페 ID가 잘못된 경우 예외처리
  - [x] 성공, 실패 테스트 코드 작성
- [x] 메뉴 상세정보 조회 API
  - [x] menu ID가 잘못된 경우 예외처리
  - [x] 성공, 실패 테스트 코드 작성 

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

