### PR TITLE
주문 내역 페이지 날짜별 내역 분리

### DIFF
--- a/packages/client/src/components/HistoryItem/index.tsx
+++ b/packages/client/src/components/HistoryItem/index.tsx
@@ -1,0 +1,56 @@
+import { History } from '@/types/OrderList';
+import { getPriceComma } from '@/utils';
+import { useMemo, useState } from 'react';
+import {
+  Container,
+  DownArrow,
+  Overview,
+  Receipt,
+  RowContainer,
+} from './styled';
+
+interface Props {
+  history: History;
+}
+
+function HistoryItem({ history }: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  /**
+   * 아래 화살표 클릭 시, 세부정보 보기 on/off
+   */
+  const handleClickOpen = () => {
+    setIsOpen(!isOpen);
+  };
+
+  /**
+   * 현재 주문의 전체 가격 계산
+   */
+  const totalPrice = useMemo(
+    () => history.menus.reduce((prev, curr) => prev + curr.price, 0),
+    [history]
+  );
+
+  return (
+    <Container>
+      <Overview>
+        <RowContainer>
+          <Receipt />
+          <p>
+            {history.menus[0].name}
+            {history.menus.length > 1
+              ? ` 외 ${history.menus.length - 1}개`
+              : ''}
+          </p>
+        </RowContainer>
+        <RowContainer>
+          <p>{getPriceComma(totalPrice)} 원</p>
+          <DownArrow onClick={handleClickOpen} />
+        </RowContainer>
+      </Overview>
+      {isOpen && <p>세부정보</p>}
+    </Container>
+  );
+}
+
+export default HistoryItem;

--- a/packages/client/src/components/HistoryItem/styled.ts
+++ b/packages/client/src/components/HistoryItem/styled.ts
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+
+import { ReactComponent as ReceiptSVG } from 'icons/receipt.svg';
+import { ReactComponent as DownArrowSVG } from 'icons/down_arrow.svg';
+
+export const Container = styled.section`
+  margin: 3% 0;
+  width: 100%;
+`;
+
+export const Overview = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+export const RowContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const Receipt = styled(ReceiptSVG)`
+  margin-right: 10px;
+`;
+
+export const DownArrow = styled(DownArrowSVG)`
+  margin-left: 10px;
+`;

--- a/packages/client/src/containers/HistoryByDate/index.tsx
+++ b/packages/client/src/containers/HistoryByDate/index.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+
+import HistoryItem from 'components/HistoryItem';
+
+import { History } from 'types/OrderList';
+import { Container } from './styled';
+
+interface Props {
+  date: string;
+  history: History[];
+}
+
+function HistoryByDate({ date, history }: Props) {
+  const historyItems = useMemo(
+    () => history.map((h) => <HistoryItem history={h} />),
+    [history]
+  );
+
+  return (
+    <Container>
+      <p>{date}</p>
+      {historyItems}
+    </Container>
+  );
+}
+
+export default HistoryByDate;

--- a/packages/client/src/containers/HistoryByDate/index.tsx
+++ b/packages/client/src/containers/HistoryByDate/index.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 function HistoryByDate({ date, history }: Props) {
   const historyItems = useMemo(
-    () => history.map((h) => <HistoryItem history={h} />),
+    () => history.map((h) => <HistoryItem history={h} key={h.id} />),
     [history]
   );
 

--- a/packages/client/src/containers/HistoryByDate/styled.ts
+++ b/packages/client/src/containers/HistoryByDate/styled.ts
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  padding: 5%;
+  width: 100%;
+`;

--- a/packages/client/src/containers/HistoryContainer/index.tsx
+++ b/packages/client/src/containers/HistoryContainer/index.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+
+import HistoryByDate from 'containers/HistoryByDate';
+
+import { orderListData } from '@/mocks/data/order';
+import { History } from 'types/OrderList';
+import { Container } from './styled';
+
+function HistoryContainer() {
+  const api = process.env.REACT_APP_API_SERVER_BASE_URL;
+  const [history, setHistory] = useState<History[] | null>(null);
+
+  /**
+   * 유저의 주문 내역 조회
+   */
+  useEffect(() => {
+    const getHistory = async () => {
+      try {
+        const res = await axios.get(`${api}/order`, { withCredentials: true });
+        setHistory(res.data);
+      } catch (err) {
+        alert('데이터 조회에 문제가 발생했습니다.');
+      }
+    };
+
+    setHistory([...orderListData]);
+    // getHistoryList();
+  }, [api]);
+
+  /**
+   * 모든 주문 내역을 날짜별 주문 내역으로 그룹화
+   */
+  const historyByDate = useMemo(() => {
+    if (!history) return {};
+
+    return history.reduce((prev: { [key: string]: History[] }, curr) => {
+      const date = curr.date;
+
+      if (!prev[date]) return { ...prev, [date]: [{ ...curr }] };
+      else return { ...prev, [date]: [...prev[date], { ...curr }] };
+    }, {});
+  }, [history]);
+
+  /**
+   * 주문 내역의 날짜들 리스트
+   */
+  const dates = useMemo(() => Object.keys(historyByDate), [historyByDate]);
+
+  /**
+   * 날짜별 내역 컨터이너들 생성
+   */
+  const HistoryByDateContainers = useMemo(() => {
+    return dates.map((date) => (
+      <HistoryByDate date={date} history={historyByDate[date]} key={date} />
+    ));
+  }, [dates, historyByDate]);
+
+  return <Container>{HistoryByDateContainers}</Container>;
+}
+
+export default HistoryContainer;

--- a/packages/client/src/containers/HistoryContainer/styled.ts
+++ b/packages/client/src/containers/HistoryContainer/styled.ts
@@ -1,0 +1,5 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  width: 100%;
+`;

--- a/packages/client/src/mocks/data/order.ts
+++ b/packages/client/src/mocks/data/order.ts
@@ -1,0 +1,34 @@
+/**
+ * 주문 내역 전체 조회?
+ */
+export const orderListData = [
+  {
+    id: 1,
+    status: 'COMPLETED',
+    date: '2022-11-22',
+    cafeId: 1,
+    menus: [
+      { id: 1, name: '아메리카노', price: 5500, options: [{}, {}] },
+      { id: 1, name: '아메리카노', price: 5500, options: [{}, {}] },
+      { id: 2, name: '카페라떼', price: 6000, options: [{}, {}] },
+    ],
+  },
+  {
+    id: 2,
+    status: 'COMPLETED',
+    date: '2022-11-22',
+    cafeId: 1,
+    menus: [
+      { id: 1, name: '아메리카노', price: 5500, options: [{}, {}] },
+      { id: 1, name: '아메리카노', price: 5500, options: [{}, {}] },
+      { id: 2, name: '카페라떼', price: 6000, options: [{}, {}] },
+    ],
+  },
+  {
+    id: 3,
+    status: 'COMPLETED',
+    date: '2022-11-21',
+    cafeId: 1,
+    menus: [{ id: 1, name: '아메리카노', price: 5500, options: [] }],
+  },
+];

--- a/packages/client/src/pages/customer/MenuDetail/index.tsx
+++ b/packages/client/src/pages/customer/MenuDetail/index.tsx
@@ -129,6 +129,7 @@ function MenuDetail() {
 
     localStorage.setItem(key, JSON.stringify(currCart));
     alert('장바구니에 담겼습니다.');
+    navigate('/menu');
   };
 
   /**

--- a/packages/client/src/pages/customer/OrderList/index.tsx
+++ b/packages/client/src/pages/customer/OrderList/index.tsx
@@ -1,40 +1,14 @@
-import { useEffect, useState } from 'react';
-
 import Header from 'components/Header';
-import { Container } from './styled';
-import Footer from '@/components/Footer';
+import Footer from 'components/Footer';
 
-import axios from 'axios';
-import { OrderListHistory } from 'types/OrderList';
-import { orderListData } from '@/mocks/data/order';
-import HistoryList from '@/containers/HistoryList';
-// import { ReactComponent as Cart } from 'icons/cart.svg';
+import { Container } from './styled';
+import HistoryContainer from 'containers/HistoryContainer';
 
 function OrderList() {
-  const api = process.env.REACT_APP_API_SERVER_BASE_URL;
-  const [orderList, setOrderList] = useState<OrderListHistory[] | null>(null);
-
-  /**
-   * 주문 리스트 조회
-   */
-  useEffect(() => {
-    const getOrderHistory = async () => {
-      try {
-        const res = await axios.get(`${api}/order`);
-        setOrderList(res.data);
-      } catch (err) {
-        alert('데이터 조회에 문제가 발생했습니다.');
-      }
-    };
-
-    setOrderList([...orderListData]);
-    // getOrderHistory();
-  }, [api]);
-
   return (
     <Container>
       <Header title="주문내역" />
-      <HistoryList />
+      <HistoryContainer />
       <Footer />
     </Container>
   );

--- a/packages/client/src/pages/customer/OrderList/styled.ts
+++ b/packages/client/src/pages/customer/OrderList/styled.ts
@@ -1,0 +1,5 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.main`
+  width: 100%;
+`;

--- a/packages/client/src/types/OrderList.ts
+++ b/packages/client/src/types/OrderList.ts
@@ -1,0 +1,13 @@
+export interface HistoryMenu {
+  id: number;
+  name: string;
+  price: number;
+  options: {}[];
+}
+
+export interface History {
+  id: number;
+  status: string;
+  date: string;
+  menus: HistoryMenu[];
+}


### PR DESCRIPTION
## 📕 주문 내역 페이지 날짜별 내역 분리
- #66 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 날짜별 내역 렌더링 컴포넌트 추가
- [x] 메뉴 상세페이지에서 장바구니 담은 후, 메뉴 목록 페이지 이동

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 주문 내역 조회 (백엔드 API 완료 시, 연동 필요)
- 주문 상세 내용 컴포넌트 추가 필요
