### PR TITLE
localStorage 장바구니 관련 작업 및 장바구니 페이지 구현

### DIFF
--- a/packages/client/src/components/Button/styled.ts
+++ b/packages/client/src/components/Button/styled.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 export const CustomButton = styled.button`
   width: 100%;
-  padding: 0.3rem 0 0.3rem 0;
+  padding: 0.3rem 1rem 0.3rem 1rem;
   background-color: ${(props) => props.theme.colors.primary};
   color: white;
   font-size: ${(props) => props.theme.font.size.xs};

--- a/packages/client/src/components/CartFooter/index.tsx
+++ b/packages/client/src/components/CartFooter/index.tsx
@@ -1,14 +1,41 @@
 import Button from 'components/Button';
 import { CartFooterWrapper, CartFooterInfoWrapper } from './styled';
+import { getPriceComma } from 'utils/index';
+import { getCart } from 'utils/localStorage';
+import { CartMenu } from '@/types/Cart';
 
-function CartFooter() {
+interface CartFooterProps {
+  count: number;
+  price: number;
+}
+
+function CartFooter({ count, price }: CartFooterProps) {
+  const handleSubmit = () => {
+    if (count === 0) return;
+    const menus = getCart().map((menu: CartMenu) => ({
+      id: menu.id,
+      name: menu.name,
+      price: menu.price,
+      size: menu.size,
+      type: menu.type,
+      quantity: menu.quantity,
+      options: menu.options.map((option) => option.id),
+    }));
+    console.log({
+      cafeId: 1,
+      menus,
+    });
+  };
+
   return (
     <CartFooterWrapper>
       <CartFooterInfoWrapper>
-        <p className={'cart-number'}>총 0개</p>
-        <p className={'cart-price'}>0원</p>
+        <p className={'cart-number'}>총 {count}개</p>
+        <p className={'cart-price'}>{getPriceComma(price)}원</p>
       </CartFooterInfoWrapper>
-      <Button className={'disabled'}>주문하기</Button>
+      <Button className={count > 0 ? '' : 'disabled'} onClick={handleSubmit}>
+        주문하기
+      </Button>
     </CartFooterWrapper>
   );
 }

--- a/packages/client/src/components/CartFooter/styled.ts
+++ b/packages/client/src/components/CartFooter/styled.ts
@@ -4,12 +4,12 @@ export const CartFooterWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  gap: 0.6rem;
   position: fixed;
   left: 0;
   bottom: 0;
   width: 100%;
-  padding: 1rem 2rem 1rem 2rem;
+  padding: 0.8rem 2rem 1rem 2rem;
   background-color: white;
   box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5),
     0px 0px 4px rgba(0, 0, 0, 0.25);

--- a/packages/client/src/components/CartFooter/styled.ts
+++ b/packages/client/src/components/CartFooter/styled.ts
@@ -10,9 +10,10 @@ export const CartFooterWrapper = styled.div`
   bottom: 0;
   width: 100%;
   padding: 1rem 2rem 1rem 2rem;
+  background-color: white;
   box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5),
     0px 0px 4px rgba(0, 0, 0, 0.25);
-`
+`;
 
 export const CartFooterInfoWrapper = styled.div`
   display: flex;
@@ -23,11 +24,11 @@ export const CartFooterInfoWrapper = styled.div`
   padding: 0 0.2rem 0 0.2rem;
   font-weight: ${(props) => props.theme.font.weight.bold700};
 
-  .cart-number{
+  .cart-number {
     font-size: ${(props) => props.theme.font.size.xs};
   }
 
-  .cart-price{
+  .cart-price {
     font-size: ${(props) => props.theme.font.size.lg};
   }
-`
+`;

--- a/packages/client/src/components/CartItem/index.tsx
+++ b/packages/client/src/components/CartItem/index.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import { CartMenu } from 'types/Cart';
 import QuantitySelector from '../QuantitySelector';
 import {
@@ -8,9 +7,10 @@ import {
   MenuOptionWrapper,
   OptionPriceWrapper,
   QuantityWrapper,
-  DeleteButton
+  DeleteButton,
 } from './styled';
 import { getMenuIdx } from 'utils/localStorage';
+import { getPriceComma } from 'utils/index';
 
 interface CartItemProps {
   menu: CartMenu;
@@ -19,9 +19,9 @@ interface CartItemProps {
 }
 
 function CartItem({ menu, setQuantity, deleteMenu }: CartItemProps) {
-  const handleClickQuantity = useCallback((quantity: number) => {
+  const handleClickQuantity = (quantity: number) => {
     setQuantity(getMenuIdx(menu), quantity);
-  }, []);
+  };
 
   const handleClickDelete = () => {
     deleteMenu(getMenuIdx(menu));
@@ -41,7 +41,7 @@ function CartItem({ menu, setQuantity, deleteMenu }: CartItemProps) {
               <p key={option.id}>{option.name}</p>
             ))}
           </MenuOptionWrapper>
-          <p>{menu.price}원</p>
+          <p>{getPriceComma(menu.price)}원</p>
         </OptionPriceWrapper>
 
         <QuantityWrapper>
@@ -49,10 +49,10 @@ function CartItem({ menu, setQuantity, deleteMenu }: CartItemProps) {
             quantity={menu.quantity}
             onClick={handleClickQuantity}
           />
-          <p>{menu.price * menu.quantity}원</p>
+          <p>{getPriceComma(menu.price * menu.quantity)}원</p>
         </QuantityWrapper>
       </MenuInfoWrapper>
-      <DeleteButton onClick={handleClickDelete}/>
+      <DeleteButton onClick={handleClickDelete} />
     </CartItemWrapper>
   );
 }

--- a/packages/client/src/components/CartItem/index.tsx
+++ b/packages/client/src/components/CartItem/index.tsx
@@ -1,0 +1,53 @@
+import { useCallback } from 'react';
+import { CartMenu } from 'types/Cart';
+import QuantitySelector from '../QuantitySelector';
+import {
+  CartItemWrapper,
+  MenuImg,
+  MenuInfoWrapper,
+  MenuOptionWrapper,
+  OptionPriceWrapper,
+  QuantityWrapper,
+} from './styled';
+import { getMenuIdx } from 'utils/localStorage';
+
+interface CartItemProps {
+  menu: CartMenu;
+  setQuantity: Function;
+}
+
+function CartItem({ menu, setQuantity }: CartItemProps) {
+  const handleClickQuantity = useCallback((quantity: number) => {
+    setQuantity(getMenuIdx(menu), quantity);
+  }, []);
+
+  return (
+    <CartItemWrapper>
+      <MenuImg src={menu.thumbnail} alt="메뉴" />
+      <MenuInfoWrapper>
+        <p>{menu.name}</p>
+        <OptionPriceWrapper>
+          <MenuOptionWrapper>
+            <p>
+              {menu.type} | {menu.size}
+            </p>
+            {menu.options.map((option) => (
+              <p key={option.id}>{option.name}</p>
+            ))}
+          </MenuOptionWrapper>
+          <p>{menu.price}원</p>
+        </OptionPriceWrapper>
+
+        <QuantityWrapper>
+          <QuantitySelector
+            quantity={menu.quantity}
+            onClick={handleClickQuantity}
+          />
+          <p>{menu.price * menu.quantity}원</p>
+        </QuantityWrapper>
+      </MenuInfoWrapper>
+    </CartItemWrapper>
+  );
+}
+
+export default CartItem;

--- a/packages/client/src/components/CartItem/index.tsx
+++ b/packages/client/src/components/CartItem/index.tsx
@@ -8,24 +8,30 @@ import {
   MenuOptionWrapper,
   OptionPriceWrapper,
   QuantityWrapper,
+  DeleteButton
 } from './styled';
 import { getMenuIdx } from 'utils/localStorage';
 
 interface CartItemProps {
   menu: CartMenu;
   setQuantity: Function;
+  deleteMenu: Function;
 }
 
-function CartItem({ menu, setQuantity }: CartItemProps) {
+function CartItem({ menu, setQuantity, deleteMenu }: CartItemProps) {
   const handleClickQuantity = useCallback((quantity: number) => {
     setQuantity(getMenuIdx(menu), quantity);
   }, []);
+
+  const handleClickDelete = () => {
+    deleteMenu(getMenuIdx(menu));
+  };
 
   return (
     <CartItemWrapper>
       <MenuImg src={menu.thumbnail} alt="메뉴" />
       <MenuInfoWrapper>
-        <p>{menu.name}</p>
+        <p className={'menu-name'}>{menu.name}</p>
         <OptionPriceWrapper>
           <MenuOptionWrapper>
             <p>
@@ -46,6 +52,7 @@ function CartItem({ menu, setQuantity }: CartItemProps) {
           <p>{menu.price * menu.quantity}원</p>
         </QuantityWrapper>
       </MenuInfoWrapper>
+      <DeleteButton onClick={handleClickDelete}/>
     </CartItemWrapper>
   );
 }

--- a/packages/client/src/components/CartItem/styled.ts
+++ b/packages/client/src/components/CartItem/styled.ts
@@ -1,0 +1,54 @@
+import styled from '@emotion/styled';
+
+export const CartItemWrapper = styled.li`
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  align-items: center;
+  width: 100%;
+  padding: 1rem 1rem 1rem 1rem;
+  border-bottom: 1px solid ${(props) => props.theme.colors.grey200};
+`;
+
+export const MenuImg = styled.img`
+  width: 4rem;
+  border-radius: 50%;
+`;
+
+export const MenuInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+
+  p {
+    font-size: ${(props) => props.theme.font.size.sm};
+  }
+`;
+
+export const OptionPriceWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  p {
+    font-size: ${(props) => props.theme.font.size.xs};
+    color: ${(props) => props.theme.colors.grey400};
+  }
+`;
+
+export const MenuOptionWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const QuantityWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+
+  p {
+    font-weight: ${(props) => props.theme.font.weight.bold700};
+  }
+`;

--- a/packages/client/src/components/CartItem/styled.ts
+++ b/packages/client/src/components/CartItem/styled.ts
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled';
+import { ReactComponent as DeleteButtonSVG } from 'icons/x_icon.svg';
 
 export const CartItemWrapper = styled.li`
   display: flex;
   flex-direction: row;
   gap: 0.5rem;
   align-items: center;
+  position: relative;
   width: 100%;
   padding: 1rem 1rem 1rem 1rem;
   border-bottom: 1px solid ${(props) => props.theme.colors.grey200};
@@ -23,6 +25,10 @@ export const MenuInfoWrapper = styled.div`
 
   p {
     font-size: ${(props) => props.theme.font.size.sm};
+  }
+
+  p.menu-name{
+    margin-right: 0.8rem;
   }
 `;
 
@@ -52,3 +58,11 @@ export const QuantityWrapper = styled.div`
     font-weight: ${(props) => props.theme.font.weight.bold700};
   }
 `;
+
+export const DeleteButton = styled(DeleteButtonSVG)`
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  width: 1rem;
+  height: 1rem;
+`

--- a/packages/client/src/components/EmptyCart/index.tsx
+++ b/packages/client/src/components/EmptyCart/index.tsx
@@ -1,0 +1,25 @@
+import Button from 'components/Button';
+import { useNavigate } from 'react-router-dom';
+import { EmptyCartWrapper } from './styled';
+
+function EmptyCart() {
+  const navigate = useNavigate();
+
+  const handleClickMenu = () => {
+    navigate('/menu');
+  };
+
+  return (
+    <EmptyCartWrapper>
+      <p className={'empty-title'}>장바구니가 비어있습니다.</p>
+      <p className={'description'}>
+        원하는 메뉴를 장바구니에 담고 한번에 주문해보세요.
+      </p>
+      <Button className={'wd-fit'} onClick={handleClickMenu}>
+        메뉴 담으러 가기
+      </Button>
+    </EmptyCartWrapper>
+  );
+}
+
+export default EmptyCart;

--- a/packages/client/src/components/EmptyCart/styled.ts
+++ b/packages/client/src/components/EmptyCart/styled.ts
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+
+export const EmptyCartWrapper = styled.div`
+  width: 100%;
+  padding: 1rem 1rem 1rem 1rem;
+
+  p {
+    padding: 0 0 0.7rem 0;
+  }
+  
+  p.empty-title { 
+    font-weight: ${(props) => props.theme.font.weight.bold700};
+  }
+
+  p.description {
+    padding-right: 5rem;
+    font-size: ${(props) => props.theme.font.size.sm};
+    color: ${(props) => props.theme.colors.grey600};
+  }
+`;

--- a/packages/client/src/components/SnackBar/index.tsx
+++ b/packages/client/src/components/SnackBar/index.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { SnackBarWrapper, CartWrapper } from './styled';
 import { ReactComponent as Cart } from 'icons/cart.svg';
-import { getCartCount } from 'utils/index';
+import { getCartCount } from 'utils/localStorage';
 
 function SnackBar() {
   const navigate = useNavigate();

--- a/packages/client/src/components/SnackBar/index.tsx
+++ b/packages/client/src/components/SnackBar/index.tsx
@@ -1,11 +1,9 @@
-import { useRecoilValue } from 'recoil';
 import { useNavigate } from 'react-router-dom';
-import { cartState } from 'utils/store';
 import { SnackBarWrapper, CartWrapper } from './styled';
 import { ReactComponent as Cart } from 'icons/cart.svg';
+import { getCartCount } from 'utils/index';
 
 function SnackBar() {
-  const cart = useRecoilValue(cartState);
   const navigate = useNavigate();
 
   const handleClickCart = () => {
@@ -16,7 +14,7 @@ function SnackBar() {
     <SnackBarWrapper>
       <p>주문할 매장을 선택해주세요</p>
       <CartWrapper onClick={handleClickCart}>
-        <p>장바구니 {cart.length}개</p>
+        <p>{`장바구니 ${getCartCount()}개`}</p>
         <Cart />
       </CartWrapper>
     </SnackBarWrapper>

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -8,3 +8,5 @@ export const SIZE_VOLUME = {
   grande: 473,
   venti: 591,
 };
+
+export const CART_KEY = 'buddhaCart';

--- a/packages/client/src/pages/customer/Cart/index.tsx
+++ b/packages/client/src/pages/customer/Cart/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { getCart, getCartCount } from 'utils/localStorage';
+import { getCart, getCartCount, getCartPrice } from 'utils/localStorage';
 import CartFooter from '@/components/CartFooter';
 import {
   CartPageWrapper,
@@ -17,6 +17,7 @@ import { useNavigate } from 'react-router-dom';
 function Cart() {
   const [cart, setCart] = useState<CartMenu[]>(getCart());
   const [cartCount, setCartCount] = useState<number>(getCartCount());
+  const [cartPrice, setCartPrice] = useState<number>(getCartPrice());
   const navigate = useNavigate();
 
   const setQuantity = (idx: number, quantity: number) => {
@@ -34,16 +35,17 @@ function Cart() {
     setCart(newCart);
     localStorage.setItem(CART_KEY, JSON.stringify(newCart));
     setCartCount(getCartCount());
+    setCartPrice(getCartPrice());
   };
 
   const handleClickBack = () => {
     navigate(-1);
-  }
+  };
 
   return (
     <CartPageWrapper>
       <FixedHeader>
-        <LeftArrow onClick={handleClickBack}/>
+        <LeftArrow onClick={handleClickBack} />
       </FixedHeader>
       <CartHeader>
         <p className={'title'}>장바구니</p>
@@ -66,7 +68,7 @@ function Cart() {
           <EmptyCart />
         )}
       </CartContentWrapper>
-      <CartFooter />
+      <CartFooter count={cartCount} price={cartPrice} />
     </CartPageWrapper>
   );
 }

--- a/packages/client/src/pages/customer/Cart/index.tsx
+++ b/packages/client/src/pages/customer/Cart/index.tsx
@@ -1,7 +1,23 @@
+import { useState } from 'react';
+import { getCart, getCartCount } from 'utils/localStorage';
 import CartFooter from '@/components/CartFooter';
 import { CartPageWrapper, CartHeader, CartContentWrapper } from './styled';
+import { CartMenu } from 'types/Cart';
+import CartItem from '@/components/CartItem';
+import { CART_KEY } from '@/constants';
 
 function Cart() {
+  const [cart, setCart] = useState<CartMenu[]>(getCart());
+  const [cartCount, setCartCount] = useState<number>(getCartCount());
+
+  const setQuantity = (idx: number, quantity: number) => {
+    let newCart = [...cart];
+    newCart[idx].quantity = quantity;
+    setCart(newCart);
+    localStorage.setItem(CART_KEY, JSON.stringify(newCart));
+    setCartCount(getCartCount());
+  };
+
   return (
     <CartPageWrapper>
       <CartHeader>
@@ -9,8 +25,12 @@ function Cart() {
         <p className={'input-cafe'}>주문할 매장을 선택해주세요</p>
       </CartHeader>
       <CartContentWrapper>
-        <p className={'title'}>담은 상품 0개</p>
-        <div></div>
+        <p className={'title'}>담은 상품 {cartCount}개</p>
+        <ul>
+          {cart.map((menu, idx) => (
+            <CartItem key={idx} menu={menu} setQuantity={setQuantity} />
+          ))}
+        </ul>
       </CartContentWrapper>
       <CartFooter />
     </CartPageWrapper>

--- a/packages/client/src/pages/customer/Cart/index.tsx
+++ b/packages/client/src/pages/customer/Cart/index.tsx
@@ -5,6 +5,7 @@ import { CartPageWrapper, CartHeader, CartContentWrapper } from './styled';
 import { CartMenu } from 'types/Cart';
 import CartItem from '@/components/CartItem';
 import { CART_KEY } from '@/constants';
+import EmptyCart from '@/components/EmptyCart';
 
 function Cart() {
   const [cart, setCart] = useState<CartMenu[]>(getCart());
@@ -35,16 +36,20 @@ function Cart() {
       </CartHeader>
       <CartContentWrapper>
         <p className={'title'}>담은 상품 {cartCount}개</p>
-        <ul>
-          {cart.map((menu, idx) => (
-            <CartItem
-              key={idx}
-              menu={menu}
-              setQuantity={setQuantity}
-              deleteMenu={deleteMenu}
-            />
-          ))}
-        </ul>
+        {cartCount > 0 ? (
+          <ul>
+            {cart.map((menu, idx) => (
+              <CartItem
+                key={idx}
+                menu={menu}
+                setQuantity={setQuantity}
+                deleteMenu={deleteMenu}
+              />
+            ))}
+          </ul>
+        ) : (
+          <EmptyCart />
+        )}
       </CartContentWrapper>
       <CartFooter />
     </CartPageWrapper>

--- a/packages/client/src/pages/customer/Cart/index.tsx
+++ b/packages/client/src/pages/customer/Cart/index.tsx
@@ -13,6 +13,15 @@ function Cart() {
   const setQuantity = (idx: number, quantity: number) => {
     let newCart = [...cart];
     newCart[idx].quantity = quantity;
+    setNewCart(newCart);
+  };
+
+  const deleteMenu = (idx: number) => {
+    let newCart = cart.filter((menu, index) => index !== idx);
+    setNewCart(newCart);
+  };
+
+  const setNewCart = (newCart: CartMenu[]) => {
     setCart(newCart);
     localStorage.setItem(CART_KEY, JSON.stringify(newCart));
     setCartCount(getCartCount());
@@ -28,7 +37,12 @@ function Cart() {
         <p className={'title'}>담은 상품 {cartCount}개</p>
         <ul>
           {cart.map((menu, idx) => (
-            <CartItem key={idx} menu={menu} setQuantity={setQuantity} />
+            <CartItem
+              key={idx}
+              menu={menu}
+              setQuantity={setQuantity}
+              deleteMenu={deleteMenu}
+            />
           ))}
         </ul>
       </CartContentWrapper>

--- a/packages/client/src/pages/customer/Cart/index.tsx
+++ b/packages/client/src/pages/customer/Cart/index.tsx
@@ -1,15 +1,23 @@
 import { useState } from 'react';
 import { getCart, getCartCount } from 'utils/localStorage';
 import CartFooter from '@/components/CartFooter';
-import { CartPageWrapper, CartHeader, CartContentWrapper } from './styled';
+import {
+  CartPageWrapper,
+  CartHeader,
+  CartContentWrapper,
+  LeftArrow,
+  FixedHeader,
+} from './styled';
 import { CartMenu } from 'types/Cart';
 import CartItem from '@/components/CartItem';
 import { CART_KEY } from '@/constants';
 import EmptyCart from '@/components/EmptyCart';
+import { useNavigate } from 'react-router-dom';
 
 function Cart() {
   const [cart, setCart] = useState<CartMenu[]>(getCart());
   const [cartCount, setCartCount] = useState<number>(getCartCount());
+  const navigate = useNavigate();
 
   const setQuantity = (idx: number, quantity: number) => {
     let newCart = [...cart];
@@ -28,8 +36,15 @@ function Cart() {
     setCartCount(getCartCount());
   };
 
+  const handleClickBack = () => {
+    navigate(-1);
+  }
+
   return (
     <CartPageWrapper>
+      <FixedHeader>
+        <LeftArrow onClick={handleClickBack}/>
+      </FixedHeader>
       <CartHeader>
         <p className={'title'}>장바구니</p>
         <p className={'input-cafe'}>주문할 매장을 선택해주세요</p>

--- a/packages/client/src/pages/customer/Cart/styled.ts
+++ b/packages/client/src/pages/customer/Cart/styled.ts
@@ -24,9 +24,10 @@ export const CartHeader = styled.div`
 
 export const CartContentWrapper = styled.div`
   width: 100%;
-  padding: 1rem 1.5rem 5rem 1.5rem;
+  padding: 1rem 0rem 5rem 0rem;
 
   .title {
+    padding: 0 1rem 0 1rem;
     font-size: ${(props) => props.theme.font.size.sm};
     font-weight: ${(props) => props.theme.font.weight.bold700};
   }

--- a/packages/client/src/pages/customer/Cart/styled.ts
+++ b/packages/client/src/pages/customer/Cart/styled.ts
@@ -1,7 +1,31 @@
 import styled from '@emotion/styled';
+import { ReactComponent as LeftArrowSVG } from 'icons/left_arrow.svg';
 
 export const CartPageWrapper = styled.div`
   width: 100%;
+`;
+
+export const FixedHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2rem;
+  background-color: ${(props) => props.theme.colors.secondary};
+  z-index: 1;
+`;
+
+export const LeftArrow = styled(LeftArrowSVG)`
+  width: 1.2rem;
+  height: 1rem;
+  padding: 0.5rem 0 0.5rem 0.4rem;
+
+  & path {
+    fill: white;
+  }
 `;
 
 export const CartHeader = styled.div`

--- a/packages/client/src/types/Cart.ts
+++ b/packages/client/src/types/Cart.ts
@@ -5,10 +5,11 @@ export interface CartMenu {
   size: string;
   quantity: number;
   price: number;
+  thumbnail: string;
   options: MenuOption[];
 }
 
-interface MenuOption {
+export interface MenuOption {
   id: number;
   name: string;
   price: number;

--- a/packages/client/src/types/Cart.ts
+++ b/packages/client/src/types/Cart.ts
@@ -1,6 +1,16 @@
 export interface CartMenu {
   id: number;
   name: string;
+  type: string;
+  size: string;
+  quantity: number;
   price: number;
-  options: number[];
+  options: MenuOption[];
+}
+
+interface MenuOption {
+  id: number;
+  name: string;
+  price: number;
+  category: string;
 }

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -1,3 +1,6 @@
+import { CART_KEY } from '@/constants';
+import { CartMenu } from 'types/Cart';
+
 /**
  * 금액 세자리 단위 콤마 추가
  */
@@ -10,4 +13,18 @@ export const getPriceComma = (price: number | string) => {
  */
 export const getFirstUpper = (text: string) => {
   return `${text.slice(0, 1).toUpperCase()}${text.slice(1)}`;
+};
+
+/**
+ * 장바구니 담긴 갯수 return
+ */
+export const getCartCount = () => {
+  const cart = JSON.parse(localStorage.getItem(CART_KEY) || '[]');
+  let count = 0;
+  
+  cart.forEach((menu: CartMenu) => {
+    count += menu.quantity;
+  });
+  
+  return count;
 };

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -1,6 +1,3 @@
-import { CART_KEY } from '@/constants';
-import { CartMenu } from 'types/Cart';
-
 /**
  * 금액 세자리 단위 콤마 추가
  */
@@ -13,18 +10,4 @@ export const getPriceComma = (price: number | string) => {
  */
 export const getFirstUpper = (text: string) => {
   return `${text.slice(0, 1).toUpperCase()}${text.slice(1)}`;
-};
-
-/**
- * 장바구니 담긴 갯수 return
- */
-export const getCartCount = () => {
-  const cart = JSON.parse(localStorage.getItem(CART_KEY) || '[]');
-  let count = 0;
-  
-  cart.forEach((menu: CartMenu) => {
-    count += menu.quantity;
-  });
-  
-  return count;
 };

--- a/packages/client/src/utils/localStorage.ts
+++ b/packages/client/src/utils/localStorage.ts
@@ -1,0 +1,42 @@
+import { CART_KEY } from '@/constants';
+import { CartMenu } from 'types/Cart';
+
+/**
+ * 장바구니 배열 return
+ */
+export const getCart = () => {
+  return JSON.parse(localStorage.getItem(CART_KEY) || '[]');
+};
+
+/**
+ * 장바구니 담긴 갯수 return
+ */
+export const getCartCount = () => {
+  const cart = getCart();
+  let count = 0;
+
+  cart.forEach((menu: CartMenu) => {
+    count += menu.quantity;
+  });
+
+  return count;
+};
+
+export const getMenu = (menu: CartMenu) => {
+  return getCart().find((cart: CartMenu) => {
+    return isEqualJSON(menu, cart);
+  });
+};
+
+export const getMenuIdx = (menu: CartMenu) => {
+  return getCart().findIndex((cart: CartMenu) => {
+    return isEqualJSON(menu, cart);
+  });
+};
+
+const isEqualJSON = (a: Object, b: Object) => {
+  return (
+    JSON.stringify(Object.entries(a).sort()) ===
+    JSON.stringify(Object.entries(b).sort())
+  );
+};

--- a/packages/client/src/utils/localStorage.ts
+++ b/packages/client/src/utils/localStorage.ts
@@ -22,6 +22,17 @@ export const getCartCount = () => {
   return count;
 };
 
+export const getCartPrice = () => {
+  const cart = getCart();
+  let price = 0;
+
+  cart.forEach((menu: CartMenu) => {
+    price += menu.price * menu.quantity;
+  });
+
+  return price;
+};
+
 export const getMenu = (menu: CartMenu) => {
   return getCart().find((cart: CartMenu) => {
     return isEqualJSON(menu, cart);


### PR DESCRIPTION
## 📕 제목
- #67 
- #72 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- 메뉴 리스트 페이지
  - [x] 장바구니 갯수 localStorage에서 가져오도록 설정
- 장바구니 페이지
  - [x] 뒤로가기 구현
  - [x] 장바구니 아이템 구현
  - [x] 장바구니 삭제 및 개수 수정 구현
  - [x] 빈 장바구니 콘텐츠 구현
  - [x] 장바구니 갯수로 버튼 활성/비활성화
  - [x] 버튼 클릭 시 API Request body에 맞게 console에 출력
- 모듈 분리
  - [x] localStorage 관련 로직들 `utils/localStorage.ts` 모듈로 분리

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- API 코드랑 합쳐져 있지 않아서 console에 찍히도록 했음
- useCallback, useMemo 등의 최적화 관련 Hooks 사용은 하지 않았음
