### PR TITLE
주문 요청 api 옵션 검사 로직, 총 금액 계산 로직 추가

### DIFF
--- a/packages/server/src/order/order.module.ts
+++ b/packages/server/src/order/order.module.ts
@@ -3,9 +3,10 @@ import { OrderService } from './order.service';
 import { OrderController } from './order.controller';
 import { Order } from './entities/order.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { MenuOption } from 'src/cafe/entities/menuOption.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Order])],
+  imports: [TypeOrmModule.forFeature([Order, MenuOption])],
   controllers: [OrderController],
   providers: [OrderService],
 })

--- a/packages/server/src/order/order.service.ts
+++ b/packages/server/src/order/order.service.ts
@@ -88,7 +88,7 @@ export class OrderService {
       const menuObj = new Menu();
 
       menuObj.id = menu.id;
-      orderMenu.price = menu.price;
+      orderMenu.price = this._getTotalPrice(menu, menuAndOptionDict);
       orderMenu.size = menu.size;
       orderMenu.type = menu.type;
       orderMenu.count = menu.count;
@@ -129,7 +129,7 @@ export class OrderService {
     return menuOptionDict;
   }
 
-  async _filterPossibleOptions(menu: OrderMenuDto, menuOptionDict) {
+  private async _filterPossibleOptions(menu: OrderMenuDto, menuOptionDict) {
     const { options } = menu;
     const menuId = menu.id;
 
@@ -138,6 +138,15 @@ export class OrderService {
     );
 
     return filteredOptions;
+  }
+
+  private _getTotalPrice(menu, menuAndOptionDict) {
+    const { options, price } = menuAndOptionDict[menu.id];
+    const totalPriceOfOptions = menu.options.reduce(
+      (partialSum, optionId) => partialSum + options[optionId],
+      0
+    );
+    return price + totalPriceOfOptions;
   }
 
   findOne(id: number) {

--- a/packages/server/src/order/order.service.ts
+++ b/packages/server/src/order/order.service.ts
@@ -1,10 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Cafe } from 'src/cafe/entities/cafe.entity';
 import { Menu } from 'src/cafe/entities/menu.entity';
+import { MenuOption } from 'src/cafe/entities/menuOption.entity';
 import { User } from 'src/user/entities/user.entity';
 import { Repository } from 'typeorm';
 import { CreateOrderDto } from './dto/create-order.dto';
+import { OrderMenuDto } from './dto/orderMenu.dto';
 import { UpdateOrderDto } from './dto/update-order.dto';
 import { Order } from './entities/order.entity';
 import { OrderMenu } from './entities/orderMenu.entity';
@@ -13,7 +15,9 @@ import { ORDER_STATUS } from './enum/orderStatus.enum';
 @Injectable()
 export class OrderService {
   constructor(
-    @InjectRepository(Order) private orderRepository: Repository<Order>
+    @InjectRepository(Order) private orderRepository: Repository<Order>,
+    @InjectRepository(MenuOption)
+    private menuOptionRepository: Repository<MenuOption>
   ) {}
 
   async getOrders(userId) {
@@ -34,6 +38,39 @@ export class OrderService {
 
   async create(userId, createOrderDto: CreateOrderDto) {
     const { menus, cafeId } = createOrderDto;
+
+    // 가능한 option들이 들어왔는지를 검증해야한다.
+
+    // menu별로 매핑된 option을 가져와야한다.
+    // menu가격, option 가격을 가져와야한다.
+
+    const menuObjs = menus.map((menu) => {
+      const menuObj = new Menu();
+      menuObj.id = menu.id;
+      return menuObj;
+    });
+    const menuAndOptionObjs = await this.menuOptionRepository.find({
+      where: { menu: menuObjs },
+      relations: {
+        option: true,
+        menu: true,
+      },
+    });
+
+    const menuAndOptionDict =
+      this._getMenuPriceAndItsOptions(menuAndOptionObjs);
+
+    for (const menu of menus) {
+      const filteredOptions = this._filterPossibleOptions(
+        menu,
+        menuAndOptionDict
+      );
+      if (menu.options.length !== (await filteredOptions).length) {
+        throw new BadRequestException(
+          '해당 메뉴에서 선택할 수 없는 옵션이 포함되어 있습니다.'
+        );
+      }
+    }
 
     const cafe = new Cafe();
     cafe.id = cafeId;
@@ -74,6 +111,33 @@ export class OrderService {
 
     await this.orderRepository.save(order);
     return;
+  }
+
+  private _getMenuPriceAndItsOptions(menuOptionObjs: MenuOption[]) {
+    const menuOptionDict = {};
+    menuOptionObjs.map((menuOptionObj) => {
+      const menu = menuOptionObj.menu;
+      const option = menuOptionObj.option;
+      if (!menuOptionDict.hasOwnProperty(menu.id)) {
+        menuOptionDict[menu.id] = {
+          price: menu.price,
+          options: {},
+        };
+      }
+      menuOptionDict[menu.id].options[option.id] = option.price;
+    });
+    return menuOptionDict;
+  }
+
+  async _filterPossibleOptions(menu: OrderMenuDto, menuOptionDict) {
+    const { options } = menu;
+    const menuId = menu.id;
+
+    const filteredOptions = options.filter((option) =>
+      menuOptionDict[menuId].options.hasOwnProperty(option)
+    );
+
+    return filteredOptions;
   }
 
   findOne(id: number) {


### PR DESCRIPTION
# 제목 - 주문 요청 api 옵션 검사 로직, 총 금액 계산 로직 추가

## 📕 제목
- #76 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 주문한 메뉴에 해당하는 결과를 menu_option 테이블에서 menu, option을 join해서 가져와 딕셔너리로 가공. 딕셔너리는 메뉴의 가격과 메뉴에서 선택가능한 옵션의 아이디와 가격을 key value작는 객체로 이루어짐
- [x] 위 객체를 토대로 메뉴에서 선택가능한 옵션이 요청으로 들어왔는지 점검하는 로직 추가
- [x] 위 객체를 토대로 메뉴, 옵션의 가격을 고려해 최종 가격 산정하는 로직 추가

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
- 기능은 구현했으나 코드가 깔끔하지 못하다. 테스트 코드를 짜며 리팩토링할 필요가 있다.