### PR TITLE
음료 가격 저장 수정

### DIFF
--- a/packages/client/src/components/OptionSelector/index.tsx
+++ b/packages/client/src/components/OptionSelector/index.tsx
@@ -36,7 +36,7 @@ function OptionItem({ option, onClick }: OptionItemProps) {
     <OptionItemContainer>
       <p>{option.name}</p>
       <div>
-        <p>{getPriceComma(option.price)} 원</p>
+        <p>+ {getPriceComma(option.price)} 원</p>
         <label>
           <input
             type="radio"

--- a/packages/client/src/components/OptionSelector/styled.ts
+++ b/packages/client/src/components/OptionSelector/styled.ts
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 export const Container = styled.section`
   margin: 5%;
+  margin-bottom: 100px;
 `;
 
 export const Title = styled.p`

--- a/packages/client/src/components/SizeSelector/index.tsx
+++ b/packages/client/src/components/SizeSelector/index.tsx
@@ -1,5 +1,11 @@
 import React, { useMemo } from 'react';
-import { Container, ItemContainer, SizeText, VolumeText } from './styled';
+import {
+  Container,
+  ItemContainer,
+  SizeIcon,
+  SizeText,
+  VolumeText,
+} from './styled';
 import { SIZE_VOLUME } from '@/constants';
 import { Size } from 'types/MenuDetail';
 import { getFirstUpper } from '@/utils';
@@ -26,7 +32,7 @@ function Item({ size, isSelected, onClick }: ItemProps) {
 
   return (
     <ItemContainer title={size} isSelected={isSelected} onClick={onClick}>
-      <p>icon</p>
+      <SizeIcon size={size} />
       {sizeText}
       {volumeText}
     </ItemContainer>

--- a/packages/client/src/components/SizeSelector/styled.ts
+++ b/packages/client/src/components/SizeSelector/styled.ts
@@ -1,5 +1,8 @@
 import styled from '@emotion/styled';
 
+import { Size } from 'types/MenuDetail';
+import { ReactComponent as SizeSVG } from 'icons/size.svg';
+
 export const Container = styled.section`
   display: flex;
   justify-content: space-around;
@@ -8,8 +11,14 @@ export const Container = styled.section`
 `;
 
 export const ItemContainer = styled.div<{ isSelected: boolean }>`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.5rem;
   width: 28%;
-  padding: 5%;
+  height: 5rem;
   border-radius: 10px;
   text-align: center;
   border: ${(props) => props.theme.border.default};
@@ -19,11 +28,25 @@ export const ItemContainer = styled.div<{ isSelected: boolean }>`
 `;
 
 export const SizeText = styled.p`
-  margin: 10% 0;
   font-size: ${(props) => props.theme.font.size.md};
 `;
 
 export const VolumeText = styled.p`
   font-size: ${(props) => props.theme.font.size.xs};
   color: ${(props) => props.theme.colors.grey600};
+`;
+
+export const SizeIcon = styled(SizeSVG)<{ size: Size }>`
+  width: ${(props) =>
+    props.size === 'tall'
+      ? '1rem'
+      : props.size === 'grande'
+      ? '1.5rem'
+      : '2rem'};
+  height: ${(props) =>
+    props.size === 'tall'
+      ? '1rem'
+      : props.size === 'grande'
+      ? '1.5rem'
+      : '2rem'};
 `;

--- a/packages/client/src/pages/customer/MenuDetail/index.tsx
+++ b/packages/client/src/pages/customer/MenuDetail/index.tsx
@@ -16,7 +16,7 @@ import {
   Img,
   MenuInfoContainer,
 } from './styled';
-import { MenuInfo, Options, Size, Type } from 'types/MenuDetail';
+import { MenuInfo, Option, Options, Size, Type } from 'types/MenuDetail';
 import { getPriceComma } from 'utils/index';
 
 function MenuDetail() {
@@ -26,6 +26,7 @@ function MenuDetail() {
   const [type, setType] = useState<Type>('hot');
   const [size, setSize] = useState<Size>('tall');
   const [options, setOptions] = useState<Options>({});
+  const [singlePrice, setSinglePrice] = useState(0);
   const [totalPrice, setTotalPrice] = useState(0);
   const { menuId } = useParams();
   const navigate = useNavigate();
@@ -105,7 +106,6 @@ function MenuDetail() {
           return {
             ...cart,
             quantity: cart.quantity + quantity,
-            price: cart.price + totalPrice,
           };
         }
         return { ...cart };
@@ -119,10 +119,17 @@ function MenuDetail() {
           type,
           size,
           quantity,
-          price: totalPrice,
-          options: Object.keys(options).map((k) => {
-            return menu.options.find((o) => o.id === Number(options[k]));
-          }),
+          thumbnail: menu.thumbnail,
+          price: singlePrice,
+          options: Object.keys(options).reduce((prev: any, curr) => {
+            if (!options[curr]) {
+              return [...prev];
+            }
+            return [
+              ...prev,
+              menu.options.find((o) => o.id === Number(options[curr])),
+            ];
+          }, []),
         },
       ];
     }
@@ -197,6 +204,8 @@ function MenuDetail() {
       price += optionPrice;
     });
 
+    setSinglePrice(price);
+
     price *= quantity;
 
     setTotalPrice(price);
@@ -210,10 +219,7 @@ function MenuDetail() {
 
     return (
       <>
-        <Img
-          src="https://www.istarbucks.co.kr/upload/store/skuimg/2022/10/[9200000004312]_20221005145029134.jpg"
-          alt="음료"
-        />
+        <Img src={menu.thumbnail} alt="음료" />
         <MenuInfoContainer>
           <h2>{menu.name}</h2>
           <p className="description">{menu.description}</p>
@@ -248,7 +254,9 @@ function MenuDetail() {
             />
           )}
           <ButtonContainer>
-            <Button onClick={handleClickOrder}>장바구니 담기</Button>
+            <Button className="wd-80" onClick={handleClickOrder}>
+              장바구니 담기
+            </Button>
           </ButtonContainer>
         </>
       )}

--- a/packages/client/src/pages/customer/MenuDetail/styled.ts
+++ b/packages/client/src/pages/customer/MenuDetail/styled.ts
@@ -46,5 +46,11 @@ export const MenuInfoContainer = styled.section`
 export const ButtonContainer = styled.div`
   display: flex;
   justify-content: center;
-  margin: 0 0 20px 0;
+  padding: 20px 0;
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  background-color: white;
+  box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5),
+    0px 0px 4px rgba(0, 0, 0, 0.25);
 `;


### PR DESCRIPTION
## 📕 음료 가격 저장 수정

- #101 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- 음료 장바구니 localStorage 에 저장 시, 음료 가격 변동 수정
- 음료 썸네일 이미지 변경
- 장바구니 저장 버튼 너비 줄이기
- 장바구니 저장 버튼 fixed
- 사이즈 아이콘 추가
- 음료 추가 가격 앞에 '+' 추가

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 뒤로가기 아이콘 컴포넌트 제작 필요
- 리팩토링 필요
