### PR TITLE
menuOptionDict의 price 필드를 menuPrice로 수정

### DIFF
--- a/packages/server/src/order/order.service.ts
+++ b/packages/server/src/order/order.service.ts
@@ -120,7 +120,7 @@ export class OrderService {
       const option = menuOptionObj.option;
       if (!menuOptionDict.hasOwnProperty(menu.id)) {
         menuOptionDict[menu.id] = {
-          price: menu.price,
+          menuPrice: menu.price,
           options: {},
         };
       }
@@ -141,12 +141,12 @@ export class OrderService {
   }
 
   private _getTotalPrice(menu, menuAndOptionDict) {
-    const { options, price } = menuAndOptionDict[menu.id];
+    const { options, menuPrice } = menuAndOptionDict[menu.id];
     const totalPriceOfOptions = menu.options.reduce(
       (partialSum, optionId) => partialSum + options[optionId],
       0
     );
-    return price + totalPriceOfOptions;
+    return menuPrice + totalPriceOfOptions;
   }
 
   findOne(id: number) {


### PR DESCRIPTION
# 제목 - menuOptionDict의 price 필드를 menuPrice로 수정

## 📕 제목
- #76 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] menuOptionDict의 price 필드를 menuPrice로 수정
