### PR TITLE
주문 상태 조회 api 구현

### DIFF
--- a/packages/server/src/order/order.controller.ts
+++ b/packages/server/src/order/order.controller.ts
@@ -33,9 +33,13 @@ export class OrderController {
     return new OrdersResDto(orders);
   }
 
+  @UseGuards(JwtGuard)
   @Get(':id')
-  getOrderStatus(@Param('id') id: string) {
-    return this.orderService.findOne(+id);
+  async getOrderStatus(@Req() req: Request, @Param('id') orderId: string) {
+    const user = req.user as JwtPayload;
+    const userId = user.id;
+    const status = await this.orderService.findOne(userId, +orderId);
+    return { order_status: status };
   }
 
   @Post()

--- a/packages/server/src/order/order.controller.ts
+++ b/packages/server/src/order/order.controller.ts
@@ -11,6 +11,7 @@ import {
   ValidationPipe,
   UsePipes,
   HttpCode,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { OrderService } from './order.service';
 import { JwtGuard } from 'src/auth/guard/jwt.guard';
@@ -36,12 +37,15 @@ export class OrderController {
 
   @UseGuards(JwtGuard)
   @Get(':id')
-  async getOrderStatus(@Req() req: Request, @Param('id') orderId: string) {
+  async getOrderStatus(
+    @Req() req: Request,
+    @Param('id', ParseIntPipe) orderId: number
+  ) {
     const user = req.user as JwtPayload;
     const userId = user.id;
     const status: ORDER_STATUS = await this.orderService.findOne(
       userId,
-      +orderId
+      orderId
     );
     return { order_status: status };
   }

--- a/packages/server/src/order/order.controller.ts
+++ b/packages/server/src/order/order.controller.ts
@@ -18,6 +18,7 @@ import { Request } from 'express';
 import { JwtPayload } from 'src/auth/interfaces/jwtPayload';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { OrdersResDto } from './dto/ordersRes.dto';
+import { ORDER_STATUS } from './enum/orderStatus.enum';
 
 @Controller()
 export class OrderController {
@@ -38,7 +39,10 @@ export class OrderController {
   async getOrderStatus(@Req() req: Request, @Param('id') orderId: string) {
     const user = req.user as JwtPayload;
     const userId = user.id;
-    const status = await this.orderService.findOne(userId, +orderId);
+    const status: ORDER_STATUS = await this.orderService.findOne(
+      userId,
+      +orderId
+    );
     return { order_status: status };
   }
 

--- a/packages/server/src/order/order.service.ts
+++ b/packages/server/src/order/order.service.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  HttpStatus,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Cafe } from 'src/cafe/entities/cafe.entity';
 import { Menu } from 'src/cafe/entities/menu.entity';
@@ -149,8 +154,25 @@ export class OrderService {
     return menuPrice + totalPriceOfOptions;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} order`;
+  async findOne(userId: number, orderId: number) {
+    const order = await this.orderRepository.findOne({
+      where: {
+        id: orderId,
+      },
+      relations: {
+        user: true,
+      },
+    });
+    if (order === null) {
+      throw new BadRequestException('해당 주문을 찾을 수 없습니다.');
+    }
+    console.log(order);
+    if (order.user.id !== userId) {
+      throw new UnauthorizedException(
+        '해당 주문의 상태 조회에 대한 접근 권한이 없습니다.'
+      );
+    }
+    return order.status;
   }
 
   update(id: number, updateOrderDto: UpdateOrderDto) {

--- a/packages/server/src/order/order.service.ts
+++ b/packages/server/src/order/order.service.ts
@@ -154,7 +154,7 @@ export class OrderService {
     return menuPrice + totalPriceOfOptions;
   }
 
-  async findOne(userId: number, orderId: number) {
+  async findOne(userId: number, orderId: number): Promise<ORDER_STATUS> {
     const order = await this.orderRepository.findOne({
       where: {
         id: orderId,


### PR DESCRIPTION


# 제목 - 주문 상태 조회 api 구현

## 📕 제목
- #76 

## 📗 작업 내용
- 주문 상태 조회 api 구현

> 구현 내용 및 작업 했던 내역

- [x] jwt 가드 추가
- [x] 존재하지 않는 주문 / 주문의 주체가 아닌 경우 http exception
- [x] 주문의 상태를 order_status라는 key에 대입해 반환한다.

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
