### PR TITLE
업주 주문 요청/수락 페이지 (상태 변경 버튼 추가)

### DIFF
--- a/packages/client/src/components/OrderDetailList/index.tsx
+++ b/packages/client/src/components/OrderDetailList/index.tsx
@@ -1,18 +1,57 @@
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
+import { useRecoilValue } from 'recoil';
+import axios from 'axios';
 
-import { DetailStatus, OrderDetailMenu, OrderStatus } from '@/types';
+import { OrderDetailMenu, OrderStatus } from '@/types';
 import { getPriceComma } from '@/utils';
-import { Container, DivisionLine, ItemContainer, PriceText } from './styled';
+import {
+  ButtonContainer,
+  Container,
+  DivisionLine,
+  ItemContainer,
+  PriceText,
+} from './styled';
+import { userRoleState } from '@/utils/store';
+import Button from '../Button';
 
 interface Props {
   date: string;
   menus: OrderDetailMenu[];
-  detailStatus?: DetailStatus;
+  status?: OrderStatus;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 interface ItemProps {
   date: string;
   menu: OrderDetailMenu;
+}
+
+interface ButtonGroupProps {
+  status?: OrderStatus;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+function ButtonGroup({ status, onClick }: ButtonGroupProps) {
+  return (
+    <ButtonContainer>
+      {status === 'REQUESTED' ? (
+        <>
+          <Button className="wd-fit" onClick={onClick}>
+            수락
+          </Button>
+          <Button className="wd-fit" onClick={onClick}>
+            거절
+          </Button>
+        </>
+      ) : status === 'ACCEPTED' ? (
+        <Button className="wd-fit" onClick={onClick}>
+          제조 완료
+        </Button>
+      ) : (
+        <></>
+      )}
+    </ButtonContainer>
+  );
 }
 
 function OrderDetailItem({ date, menu }: ItemProps) {
@@ -24,7 +63,9 @@ function OrderDetailItem({ date, menu }: ItemProps) {
   );
 }
 
-function OrderDetailList({ date, menus, detailStatus }: Props) {
+function OrderDetailList({ date, menus, status, onClick }: Props) {
+  const userRole = useRecoilValue(userRoleState);
+
   const totalPrice = useMemo(() => {
     return menus.reduce((prev, curr) => prev + curr.price, 0);
   }, [menus]);
@@ -44,6 +85,9 @@ function OrderDetailList({ date, menus, detailStatus }: Props) {
         <p>총 액</p>
         <PriceText>{`${getPriceComma(totalPrice)} 원`}</PriceText>
       </ItemContainer>
+      {userRole === 'MANAGER' && (
+        <ButtonGroup status={status} onClick={onClick} />
+      )}
     </Container>
   );
 }

--- a/packages/client/src/components/OrderDetailList/styled.ts
+++ b/packages/client/src/components/OrderDetailList/styled.ts
@@ -30,3 +30,9 @@ export const PriceText = styled.p`
   margin: 0 0 0 0.7rem;
   white-space: nowrap;
 `;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+`;

--- a/packages/client/src/components/OrderList/index.tsx
+++ b/packages/client/src/components/OrderList/index.tsx
@@ -13,8 +13,7 @@ import {
   Receipt,
   RowContainer,
 } from './styled';
-import { useRecoilValue } from 'recoil';
-import { userRoleState } from '@/utils/store';
+import axios from 'axios';
 
 interface Props {
   date: string;
@@ -27,10 +26,32 @@ interface ItemProps {
 }
 
 function OrderItem({ date, order }: ItemProps) {
-  const userRole = useRecoilValue(userRoleState);
+  const api = process.env.REACT_APP_API_SERVER_BASE_URL;
   const [isOpen, setIsOpen] = useState(false);
 
   const handleClickOpen = () => setIsOpen(!isOpen);
+
+  const handleClickOrder = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const text = event.currentTarget.innerHTML;
+
+    const postOrder = async () => {
+      let action;
+      if (text === '수락') action = 'accepted';
+      else if (text === '거절') action = 'rejected';
+      else if (text === '제조 완료') action = 'completed';
+
+      try {
+        await axios.post(
+          `${api}/order/${action}`,
+          { id: order.id, newStatus: action?.toUpperCase() },
+          { withCredentials: true }
+        );
+      } catch (err) {
+        alert('주문에 문제가 발생했습니다.');
+      }
+    };
+    postOrder();
+  };
 
   const totalPrice = useMemo(
     () => order.menus.reduce((prev, curr) => prev + curr.price, 0),
@@ -52,7 +73,14 @@ function OrderItem({ date, order }: ItemProps) {
           <DownArrow onClick={handleClickOpen} />
         </RowContainer>
       </Overview>
-      {isOpen && <OrderDetailList date={date} menus={order.menus} />}
+      {isOpen && (
+        <OrderDetailList
+          date={date}
+          menus={order.menus}
+          status={order.status}
+          onClick={handleClickOrder}
+        />
+      )}
     </ItemContainer>
   );
 }

--- a/packages/client/src/hooks/useFetch.tsx
+++ b/packages/client/src/hooks/useFetch.tsx
@@ -1,6 +1,7 @@
 import { AnyObject, APIMethod } from '@/types';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 interface Params {
   url: string;
@@ -11,6 +12,7 @@ interface Params {
 function useFetch({ url, method, data }: Params) {
   const api = process.env.REACT_APP_API_SERVER_BASE_URL;
   const [jsonData, setJsonData] = useState<AnyObject>({});
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!api || !method || !url) return;
@@ -26,11 +28,16 @@ function useFetch({ url, method, data }: Params) {
 
         setJsonData(res.data);
       } catch (err) {
+        const { response } = err as AxiosError;
+
+        if (response?.status === 401) {
+          navigate('/');
+        }
         alert('오류가 발생했습니다.\n다시 시도해주세요.');
       }
     };
     fetch();
-  }, [api, url, method, data]);
+  }, [api, url, method, data, navigate]);
 
   return { jsonData };
 }

--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -4,7 +4,6 @@ export type UserRole = 'CLIENT' | 'MANAGER';
 export type Temperature = 'hot' | 'iced';
 export type Size = 'tall' | 'grande' | 'venti';
 export type OrderStatus = 'REQUESTED' | 'ACCEPTED' | 'REJECTED' | 'COMPLETED';
-export type DetailStatus = 'REQUESTED' | 'ACCEPTED';
 export type AnyObject = { [key: string]: any };
 
 // Signin.ts

--- a/packages/client/src/utils/store.ts
+++ b/packages/client/src/utils/store.ts
@@ -1,13 +1,12 @@
 import { atom } from 'recoil';
-import { CartMenu } from '@/types';
+import { CartMenu, UserRole } from '@/types';
 
 export const cartState = atom<CartMenu[]>({
   key: 'cartState',
   default: [],
 });
 
-type userRole = 'CLIENT' | 'MANAGER';
-export const userRoleState = atom<userRole>({
+export const userRoleState = atom<UserRole>({
   key: 'userRoleState',
   default: 'CLIENT',
 });


### PR DESCRIPTION
# 📕 제목
- #66 
- #134 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 수락/거절/완료 버튼 추가
- [x] useFetch 훅에서 미권한으로 접근 시, 로그인 페이지 이동으로 수정

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 주문 상태 변경 버튼 클릭 후, 새로운 목록 가져오기 미구현
- react query 를 이용할건지 의논 필요