### PR TITLE
주문 내역 응답 객체 date 형식 변경

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,6 +36,7 @@
     "cross-env": "^7.0.3",
     "docker-compose": "^0.23.17",
     "express-session": "^1.17.3",
+    "moment": "^2.29.4",
     "mysql2": "^2.3.3",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.0",

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -29,6 +29,7 @@ import { RouterModule } from '@nestjs/core';
           entities: ['dist/**/*.entity{.ts,.js}'],
           synchronize: configService.get('NODE_ENV') === 'development',
           logging: true,
+          timezone: 'Asia/Seoul',
         };
       },
       inject: [ConfigService],

--- a/packages/server/src/order/dto/ordersRes.dto.ts
+++ b/packages/server/src/order/dto/ordersRes.dto.ts
@@ -1,3 +1,4 @@
+import { DateTimeUtil } from './../../utils/dateTime.util';
 import { Exclude, Expose } from 'class-transformer';
 import { Cafe } from 'src/cafe/entities/cafe.entity';
 import { Menu } from 'src/cafe/entities/menu.entity';
@@ -51,8 +52,8 @@ export class OrdersOrderDto {
   }
 
   @Expose()
-  get date(): Date {
-    return this._date;
+  get date(): string {
+    return DateTimeUtil.toString(this._date);
   }
 
   @Expose()

--- a/packages/server/src/utils/dateTime.util.spec.ts
+++ b/packages/server/src/utils/dateTime.util.spec.ts
@@ -1,0 +1,16 @@
+import { DateTimeUtil } from './dateTime.util';
+
+describe('DateTime Util', () => {
+  it('toString()', () => {
+    // given
+    const now = new Date();
+
+    // when
+    const newDate = DateTimeUtil.toString(now);
+
+    // then
+    expect(newDate.toString().substring(0, 10)).toBe(
+      now.toISOString().substring(0, 10)
+    );
+  });
+});

--- a/packages/server/src/utils/dateTime.util.ts
+++ b/packages/server/src/utils/dateTime.util.ts
@@ -1,0 +1,17 @@
+import moment from 'moment';
+
+const DAYS = [
+  '일요일',
+  '월요일',
+  '화요일',
+  '수요일',
+  '목요일',
+  '금요일',
+  '토요일',
+];
+
+export class DateTimeUtil {
+  static toString(date: Date): string {
+    return moment(date).format('YYYY-MM-DD-HH:MM-') + DAYS[date.getDay()];
+  }
+}


### PR DESCRIPTION
## 📕 주문 내역 응답 객체 date 형식 변경

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] moment module로 date 형식 변경해주는 util 함수 작성
- [x] typeORM timezone 설정
- [x] util 함수 테스트 코드 작성

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- MySQL docker 실행할 때 -e TZ-Asia/Seoul 추가해줘야함
- docker container run -p 3306:3306 -v mysql-volume:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=buddah159 -e TZ=Asia/Seoul --name mysql -d mysql:8.0
