### PR TITLE
singUp 시 쿠키에 Access Token 주입해서 응답하도록 수정

### DIFF
--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -45,8 +45,20 @@ export class AuthController {
   // 회원가입
   @Post('/signup')
   @HttpCode(201)
-  async signUp(@Req() req: Request, @Body() signUpDto: SignUpDto) {
-    return await this.authService.signUp(req, signUpDto);
+  async signUp(
+    @Req() req: Request,
+    @Res() res: Response,
+    @Body() signUpDto: SignUpDto
+  ) {
+    const { accessToken } = await this.authService.signUp(req, signUpDto);
+
+    res.cookie('accessToken', accessToken, {
+      // domain: process.env.DOMAIN,
+      // path: '/',
+      httpOnly: true,
+    });
+
+    return res.end();
   }
 
   // 유저 권한 확인


### PR DESCRIPTION
## 📕 singUp 시 쿠키에 Access Token 주입해서 응답하도록 수정

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] signUp시 Access Token 발급안하던 문제 수정

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Access Token은 쿠키에 실어서 응답한다.
