### PR TITLE
유저 권한별 라우팅 설정으로 인한 테스트 코드 리팩토링

### DIFF
--- a/packages/client/src/components/Footer/index.spec.tsx
+++ b/packages/client/src/components/Footer/index.spec.tsx
@@ -2,20 +2,13 @@ import { screen, fireEvent } from '@testing-library/react';
 import { server } from '@/mocks/server';
 import { setup, setupClient, setupManager } from 'utils/testSetup';
 
-import { rest } from 'msw';
-const api = process.env.REACT_APP_API_SERVER_BASE_URL;
-
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe('Footer', () => {
   it('(고객) Home 클릭 시 주문내역 화면으로 전환', async () => {
-    server.use(
-      rest.get(`${api}/auth`, (req, res, next) => {
-        return res(next.json({ role: 'CLIENT' }));
-      })
-    );
+    setupClient();
     setup({ url: '/' });
 
     fireEvent.click(await screen.findByText('Home'));

--- a/packages/client/src/components/Footer/index.spec.tsx
+++ b/packages/client/src/components/Footer/index.spec.tsx
@@ -1,36 +1,48 @@
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import { server } from '@/mocks/server';
-import { setup } from 'utils/testSetup';
+import { setup, setupClient, setupManager } from 'utils/testSetup';
+
+import { rest } from 'msw';
+const api = process.env.REACT_APP_API_SERVER_BASE_URL;
 
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe('Footer', () => {
-  it('Home 클릭 시 주문내역 화면으로 전환', async () => {
-    setup({ url: '/home' });
+  it('(고객) Home 클릭 시 주문내역 화면으로 전환', async () => {
+    server.use(
+      rest.get(`${api}/auth`, (req, res, next) => {
+        return res(next.json({ role: 'CLIENT' }));
+      })
+    );
+    setup({ url: '/' });
 
-    fireEvent.click(screen.getByText('Home'));
-    await waitFor(() => {
-      screen.getByText('주문내역');
-    });
+    fireEvent.click(await screen.findByText('Home'));
+    await screen.findByText('주문내역');
   });
 
-  it('Order 클릭 시 메뉴 내역 화면으로 전환', async () => {
-    setup({ url: '/home' });
+  it('(고객) Order 클릭 시 메뉴 내역 화면으로 전환', async () => {
+    setupClient();
+    setup({ url: '/' });
 
-    fireEvent.click(screen.getByText('Order'));
-    await waitFor(() => {
-      screen.getByTestId('menu-list-page');
-    });
+    fireEvent.click(await screen.findByText('Order'));
+    await screen.findByTestId('menu-list-page');
   });
 
-  it('MY 클릭 시 마이페이지 화면으로 전환', async () => {
-    setup({ url: '/home' });
+  it('(업주) Home 클릭 시 주문 요청 내역 화면으로 전환', async () => {
+    setupManager();
+    setup({ url: '/' });
 
-    fireEvent.click(screen.getByText('MY'));
-    await waitFor(() => {
-      screen.getByTestId('my-page');
-    });
+    fireEvent.click(await screen.findByText('새 주문'));
+    await screen.findByText('주문 요청 내역');
+  });
+
+  it('(공통) MY 클릭 시 마이페이지 화면으로 전환', async () => {
+    setupClient();
+    setup({ url: '/' });
+
+    fireEvent.click(await screen.findByText('MY'));
+    await screen.findByTestId('my-page');
   });
 });

--- a/packages/client/src/mocks/data/order.ts
+++ b/packages/client/src/mocks/data/order.ts
@@ -32,3 +32,22 @@ export const orderListData = [
     menus: [{ id: 1, name: '아메리카노', price: 5500, options: [] }],
   },
 ];
+
+export const requestedOrderData = {
+  orders: [
+    {
+      cafeId: 1,
+      date: '2022-12-08-23:12-목요일',
+      id: 37,
+      menus: [
+        {
+          id: 57,
+          name: '화이트 초콜릿 모카',
+          options: { 1: '에스프레소 샷 추가' },
+          price: 5000,
+        },
+      ],
+      status: 'REQUESTED',
+    },
+  ],
+};

--- a/packages/client/src/mocks/handlers/auth.ts
+++ b/packages/client/src/mocks/handlers/auth.ts
@@ -31,4 +31,7 @@ export const authHandlers = [
       }
     }
   ),
+  rest.get(`${api}/auth`, (req, res, next) => {
+    return res(next.json({ role: 'UNAUTH' }));
+  }),
 ];

--- a/packages/client/src/mocks/handlers/order.ts
+++ b/packages/client/src/mocks/handlers/order.ts
@@ -1,10 +1,13 @@
 import { rest } from 'msw';
-import { orderListData } from '@/mocks/data/order';
+import { orderListData, requestedOrderData } from '@/mocks/data/order';
 
 const api = process.env.REACT_APP_API_SERVER_BASE_URL;
 
 export const orderHandlers = [
   rest.get(`${api}/order`, (req, res, next) => {
     return res(next.json(orderListData));
+  }),
+  rest.get(`${api}/order/requested`, (req, res, next) => {
+    return res(next.json(requestedOrderData));
   }),
 ];

--- a/packages/client/src/pages/Signin/index.spec.tsx
+++ b/packages/client/src/pages/Signin/index.spec.tsx
@@ -1,8 +1,8 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 import { server } from '@/mocks/server';
 import { PLACEHOLDER } from '@/constants';
-import { setup } from 'utils/testSetup';
+import { setup, setupClient } from 'utils/testSetup';
 
 beforeAll(() => server.listen());
 beforeEach(() => server.resetHandlers());
@@ -56,24 +56,21 @@ describe('로그인 페이지', () => {
   it('미가입 유저 => 회원가입 페이지 이동', async () => {
     setup({ url: '/?code=qwer1234&state=1234' });
 
-    await waitFor(() => {
-      screen.getByText('고객');
-      screen.getByText('업주');
-      screen.getByPlaceholderText(PLACEHOLDER.nickname);
-      screen.getByText('회원가입');
-    });
+    await screen.findByText('고객');
+    await screen.findByText('업주');
+    await screen.findByPlaceholderText(PLACEHOLDER.nickname);
+    await screen.findByText('회원가입');
   });
 
   it('가입 유저 => 고객 주문 내역 페이지 이동', async () => {
+    setupClient();
     setup({ url: '/?code=qwer1234&state=1234' });
 
     Object.defineProperty(window.document, 'cookie', {
       value: 'name=이름;email=test@test.com',
     });
 
-    await waitFor(() => {
-      screen.getByText(/주문내역/i);
-    });
+    await screen.findByText(/주문내역/i);
   });
 
   it('스냡샷', () => {

--- a/packages/client/src/pages/Signup/index.spec.tsx
+++ b/packages/client/src/pages/Signup/index.spec.tsx
@@ -1,7 +1,7 @@
 import { screen, fireEvent } from '@testing-library/react';
 import { PLACEHOLDER } from '@/constants';
 import { server } from '@/mocks/server';
-import { setup } from 'utils/testSetup';
+import { setup, setupClient, setupManager } from 'utils/testSetup';
 
 // jest 테스트 수명주기에 따라 server 상태 정의
 beforeAll(() => server.listen());
@@ -89,6 +89,7 @@ describe('회원가입 페이지', () => {
   });
 
   it('정상 입력 후 가입 버튼을 눌렀을 때 페이지 이동 (고객용)', async () => {
+    setupClient();
     setup({ url: '/signup' });
 
     const { inputNickname } = getInputNickname();
@@ -100,6 +101,7 @@ describe('회원가입 페이지', () => {
   });
 
   it('정상 입력 후 가입 버튼을 눌렀을 때 페이지 이동 (업주용)', async () => {
+    setupManager();
     setup({ url: '/signup' });
 
     fireEvent.click(screen.getByText('업주'));
@@ -113,6 +115,6 @@ describe('회원가입 페이지', () => {
     expect(inputCorporate.value).toBe('123-456-7890');
 
     fireEvent.click(screen.getByText('회원가입'));
-    await screen.findByText('주문내역');
+    await screen.findByText('주문 요청 내역');
   });
 });

--- a/packages/client/src/pages/customer/Cart/components/CartFooter/index.tsx
+++ b/packages/client/src/pages/customer/Cart/components/CartFooter/index.tsx
@@ -37,7 +37,7 @@ function CartFooter({ count, price }: CartFooterProps) {
       );
       window.localStorage.removeItem(CART_KEY);
       alert('주문 완료');
-      navigate('/home');
+      navigate('/');
     } catch (err) {
       console.log(err);
     }

--- a/packages/client/src/pages/customer/Cart/index.spec.tsx
+++ b/packages/client/src/pages/customer/Cart/index.spec.tsx
@@ -1,20 +1,17 @@
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { server } from '@/mocks/server';
-import { setup } from 'utils/testSetup';
+import { setup, setupClient } from 'utils/testSetup';
 
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-describe('MenuList', () => {
+describe('Cart', () => {
   it('컴포넌트 검사', async () => {
+    setupClient();
     setup({ url: '/cart' });
 
-    screen.getByTestId('cart-content');
-    screen.getByText('주문하기');
-  });
-
-  it('메뉴 선택시 메뉴 상세 화면으로 전환', async () => {
-    setup({ url: '/cart' });
+    await screen.findByTestId('cart-content');
+    await screen.findByText('주문하기');
   });
 });

--- a/packages/client/src/pages/customer/MenuDetail/index.test.tsx
+++ b/packages/client/src/pages/customer/MenuDetail/index.test.tsx
@@ -1,29 +1,20 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { fireEvent, screen } from '@testing-library/react';
 
-import Layout from '@/Layout';
-import Router from '@/Router';
 import { server } from '@/mocks/server';
+import { setup, setupClient } from '@/utils/testSetup';
 
 beforeAll(() => server.listen());
 beforeEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-const setup = ({ menuId }: { menuId: number }) => {
-  const { asFragment } = render(
-    <Layout>
-      <MemoryRouter initialEntries={[`/menu/${menuId}`]}>
-        <Router />
-      </MemoryRouter>
-    </Layout>
-  );
-
-  return { asFragment };
+const detailSetup = ({ menuId }: { menuId: number }) => {
+  setupClient();
+  return setup({ url: `/menu/${menuId}` });
 };
 
 describe('메뉴 상세 조회 페이지', () => {
   it('요소 존재 여부', async () => {
-    setup({ menuId: 1 });
+    detailSetup({ menuId: 1 });
 
     await screen.findByAltText(/음료/);
     await screen.findByText(/자몽 허니 블랙 티/);
@@ -35,13 +26,13 @@ describe('메뉴 상세 조회 페이지', () => {
   });
 
   it('조회 실패', async () => {
-    setup({ menuId: 2 });
+    detailSetup({ menuId: 2 });
 
     Object.defineProperty(window, 'alert', { value: jest.fn() });
   });
 
   it('주문 -> 장바구니 추가 및 페이지 이동', async () => {
-    setup({ menuId: 1 });
+    detailSetup({ menuId: 1 });
 
     const minus = await screen.findByTestId(/minus/);
     const plus = await screen.findByTestId(/plus/);
@@ -85,7 +76,7 @@ describe('메뉴 상세 조회 페이지', () => {
   });
 
   it('메뉴 목록 페이지 이동', async () => {
-    setup({ menuId: 1 });
+    detailSetup({ menuId: 1 });
 
     const order = await screen.findByText(/장바구니 담기/);
 

--- a/packages/client/src/pages/customer/MenuDetail/index.test.tsx
+++ b/packages/client/src/pages/customer/MenuDetail/index.test.tsx
@@ -74,13 +74,4 @@ describe('메뉴 상세 조회 페이지', () => {
     expect(received).toStrictEqual(expected);
     await screen.findByTestId(/menu-list-page/);
   });
-
-  it('메뉴 목록 페이지 이동', async () => {
-    detailSetup({ menuId: 1 });
-
-    const order = await screen.findByText(/장바구니 담기/);
-
-    fireEvent.click(order);
-    await screen.findByTestId('menu-list-page');
-  });
 });

--- a/packages/client/src/pages/customer/MenuList/index.spec.tsx
+++ b/packages/client/src/pages/customer/MenuList/index.spec.tsx
@@ -1,6 +1,6 @@
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { server } from '@/mocks/server';
-import { setup } from 'utils/testSetup';
+import { setup, setupClient } from 'utils/testSetup';
 
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
@@ -8,6 +8,7 @@ afterAll(() => server.close());
 
 describe('MenuList', () => {
   it('컴포넌트 검사', async () => {
+    setupClient();
     setup({ url: '/menu' });
 
     const menuItems = await screen.findAllByTestId('menu-item');
@@ -18,6 +19,7 @@ describe('MenuList', () => {
   });
 
   it('카테고리 클릭시 카테고리 전환', async () => {
+    setupClient();
     setup({ url: '/menu' });
 
     fireEvent.click(await screen.findByText('콜드 브루'));
@@ -28,21 +30,19 @@ describe('MenuList', () => {
   });
 
   it('메뉴 선택시 메뉴 상세 화면으로 전환', async () => {
+    setupClient();
     setup({ url: '/menu' });
 
     const menuItems = await screen.findAllByTestId('menu-item');
     fireEvent.click(menuItems[0]);
-    // await waitFor(() => {
-    //   screen.getByTestId('menu-detail-page');
-    // });
+    await screen.findByTestId('menu-detail-page');
   });
 
   it('장바구니 클릭시 장바구니 화면으로 전환', async () => {
+    setupClient();
     setup({ url: '/menu' });
 
-    fireEvent.click(screen.getByTestId('cart-button'));
-    await waitFor(() => {
-      screen.getByText('장바구니');
-    })
+    fireEvent.click(await screen.findByTestId('cart-button'));
+    await screen.findByText('장바구니');
   });
 });

--- a/packages/client/src/utils/testSetup.tsx
+++ b/packages/client/src/utils/testSetup.tsx
@@ -4,17 +4,40 @@ import { MemoryRouter } from 'react-router-dom';
 import Router from '@/Router';
 import Layout from '@/Layout';
 import { RecoilRoot } from 'recoil';
+import UserRoleProvider from '@/UserRoleProvider';
+import { server } from '@/mocks/server';
+import { rest } from 'msw';
+
+const api = process.env.REACT_APP_API_SERVER_BASE_URL;
 
 export const setup = ({ url }: { url: string }) => {
   const { asFragment } = render(
     <RecoilRoot>
-      <Layout>
-        <MemoryRouter initialEntries={[url]}>
-          <Router />
-        </MemoryRouter>
-      </Layout>
+      <UserRoleProvider>
+        <Layout>
+          <MemoryRouter initialEntries={[url]}>
+            <Router />
+          </MemoryRouter>
+        </Layout>
+      </UserRoleProvider>
     </RecoilRoot>
   );
 
   return { asFragment };
+};
+
+export const setupClient = () => {
+  server.use(
+    rest.get(`${api}/auth`, (req, res, next) => {
+      return res(next.json({ role: 'CLIENT' }));
+    })
+  );
+};
+
+export const setupManager = () => {
+  server.use(
+    rest.get(`${api}/auth`, (req, res, next) => {
+      return res(next.json({ role: 'MANAGER' }));
+    })
+  );
 };

--- a/packages/client/src/utils/testSetup.tsx
+++ b/packages/client/src/utils/testSetup.tsx
@@ -7,20 +7,25 @@ import { RecoilRoot } from 'recoil';
 import UserRoleProvider from '@/UserRoleProvider';
 import { server } from '@/mocks/server';
 import { rest } from 'msw';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const api = process.env.REACT_APP_API_SERVER_BASE_URL;
 
 export const setup = ({ url }: { url: string }) => {
+  const queryClient = new QueryClient();
+
   const { asFragment } = render(
-    <RecoilRoot>
-      <UserRoleProvider>
-        <Layout>
-          <MemoryRouter initialEntries={[url]}>
-            <Router />
-          </MemoryRouter>
-        </Layout>
-      </UserRoleProvider>
-    </RecoilRoot>
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <UserRoleProvider>
+          <Layout>
+            <MemoryRouter initialEntries={[url]}>
+              <Router />
+            </MemoryRouter>
+          </Layout>
+        </UserRoleProvider>
+      </RecoilRoot>
+    </QueryClientProvider>
   );
 
   return { asFragment };


### PR DESCRIPTION
## 📕 유저 권한별 라우팅 설정으로 인한 테스트 코드 리팩토링

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 유저 권한 Mock API 추가
- [x] `setupClient`, `setupManager` 함수로 유저 권한 설정할 수 있도록 분리
- [x] `REQUESTED` 상태 주문 Mock API / 데이터 추가
- [x] 권한별 라우팅으로 인한 대규모 테스트 코드 수정
  - 로그인 페이지
  - 회원가입 페이지
  - 메뉴 목록 페이지
  - 메뉴 상세 페이지
  - Footer 컴포넌트
  - 장바구니 페이지

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 테스트 진행 간 아래와 같은 react-router쪽 Warning이 가끔 발생
```
You should call navigate() in a React.useEffect(), not when your component is first rendered.
```

- 이를 해결할 수 있는 방법을 찾아보던 중 react-router쪽 이슈를 찾아보니, 아직 열려있는 이슈이고 해당 Warning은  `test`진행 시에 발생할 수 있는 버그라고 함
  - 화면 render가 일어난 직후 바로 click 이벤트를 발생시키면 event가 lost 될 수도 있다고 한다...
- https://github.com/remix-run/react-router/issues/8809
