### PR TITLE
업주 주문 목록 페이지 초기 설정 변경

### DIFF
--- a/packages/client/src/components/OrderDateList/index.tsx
+++ b/packages/client/src/components/OrderDateList/index.tsx
@@ -3,19 +3,24 @@ import { memo, useMemo } from 'react';
 import OrderList from 'components/OrderList';
 
 import { Order, OrderStatusCode } from '@/types';
-import { Container, ItemContainer } from './styled';
+import { Container, ItemContainer, NoOrderContainer } from './styled';
 import useOrderGroup from 'hooks/useOrderDates';
 import { sortDateDesc } from '@/utils';
 
 interface Props {
   list: Order[];
   status?: OrderStatusCode[];
+  noBottomPadding?: boolean;
 }
 
 interface ItemProps {
   date: string;
   orders: Order[];
 }
+
+const NoOrder = function () {
+  return <NoOrderContainer>진행중인 내역이 없습니다...</NoOrderContainer>;
+};
 
 const OrderDateItem = memo(function ({ date, orders }: ItemProps) {
   return (
@@ -26,7 +31,7 @@ const OrderDateItem = memo(function ({ date, orders }: ItemProps) {
   );
 });
 
-function OrderDateList({ list, status }: Props) {
+function OrderDateList({ list, status, noBottomPadding }: Props) {
   const { orderGroup } = useOrderGroup({ list, status });
 
   const items = useMemo(() => {
@@ -39,7 +44,11 @@ function OrderDateList({ list, status }: Props) {
       });
   }, [orderGroup]);
 
-  return <Container>{items}</Container>;
+  return (
+    <Container noBottomPadding>
+      {items.length > 0 ? items : <NoOrder />}
+    </Container>
+  );
 }
 
 export default memo(OrderDateList);

--- a/packages/client/src/components/OrderDateList/styled.ts
+++ b/packages/client/src/components/OrderDateList/styled.ts
@@ -1,10 +1,18 @@
 import styled from '@emotion/styled';
 
-export const Container = styled.section`
-  padding: 0 0 3rem 0;
+export const Container = styled.section<{ noBottomPadding?: boolean }>`
+  padding: 0 0
+    ${({ noBottomPadding }) => (noBottomPadding === true ? '0' : '3rem')} 0;
 `;
 
 export const ItemContainer = styled.div`
-  padding: 5%;
+  padding: 1rem;
   width: 100%;
+`;
+
+export const NoOrderContainer = styled.div`
+  margin: 0.5rem 1rem;
+  padding: 1.5rem;
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.colors.fourth};
 `;

--- a/packages/client/src/components/OrderList/index.tsx
+++ b/packages/client/src/components/OrderList/index.tsx
@@ -17,6 +17,8 @@ import {
   Receipt,
   RowContainer,
 } from './styled';
+import { useRecoilValue } from 'recoil';
+import { userRoleState } from '@/stores';
 
 interface Props {
   date: string;
@@ -29,7 +31,8 @@ interface ItemProps {
 }
 
 function OrderItem({ date, order }: ItemProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const userRole = useRecoilValue(userRoleState);
+  const [isOpen, setIsOpen] = useState(userRole === 'MANAGER' ? true : false);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 

--- a/packages/client/src/pages/Home/index.tsx
+++ b/packages/client/src/pages/Home/index.tsx
@@ -20,7 +20,11 @@ function Home() {
     <Container>
       <Header title={userRole === 'CLIENT' ? '주문 내역' : '주문 요청 내역'} />
       {userRole === 'CLIENT' && (
-        <OrderDateList list={list.orders} status={['REQUESTED', 'ACCEPTED']} />
+        <OrderDateList
+          list={list.orders}
+          status={['REQUESTED', 'ACCEPTED']}
+          noBottomPadding={true}
+        />
       )}
       {list.orders && (
         <OrderDateList


### PR DESCRIPTION
## 📕 업주 주문 목록 페이지 초기 설정 변경

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 업주 주문 목록 페이지 초기 접속 시, 상세 정보 오픈 상태로 기본 설정 변경
- [x] 진행중인 주문 내역이 없으면 알림 텍스트 표시
