### PR TITLE
업주 주문 내역 페이지 수정

### DIFF
--- a/packages/client/src/components/OrderDateList/index.tsx
+++ b/packages/client/src/components/OrderDateList/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import React, { memo, ReactNode, useMemo } from 'react';
 
 import OrderList from 'components/OrderList';
 
@@ -6,6 +6,8 @@ import { Order, OrderStatusCode } from '@/types';
 import { Container, ItemContainer, NoOrderContainer } from './styled';
 import useOrderGroup from 'hooks/useOrderDates';
 import { sortDateDesc } from '@/utils';
+import { useRecoilValue } from 'recoil';
+import { userRoleState } from '@/stores';
 
 interface Props {
   list: Order[];
@@ -18,20 +20,21 @@ interface ItemProps {
   orders: Order[];
 }
 
-const NoOrder = function () {
-  return <NoOrderContainer>진행중인 내역이 없습니다...</NoOrderContainer>;
+const NoOrder = function ({ children }: { children: ReactNode }) {
+  return <NoOrderContainer>{children}</NoOrderContainer>;
 };
 
 const OrderDateItem = memo(function ({ date, orders }: ItemProps) {
   return (
     <ItemContainer>
-      <p className='date-title'>{date}</p>
+      <p className="date-title">{date}</p>
       <OrderList date={date} orders={orders} />
     </ItemContainer>
   );
 });
 
 function OrderDateList({ list, status, noBottomPadding }: Props) {
+  const userRole = useRecoilValue(userRoleState);
   const { orderGroup } = useOrderGroup({ list, status });
 
   const items = useMemo(() => {
@@ -45,8 +48,15 @@ function OrderDateList({ list, status, noBottomPadding }: Props) {
   }, [orderGroup]);
 
   return (
-    <Container noBottomPadding={noBottomPadding} >
-      {items.length > 0 || !noBottomPadding ? items : <NoOrder />}
+    <Container noBottomPadding={noBottomPadding}>
+      {items.length > 0 || !noBottomPadding ? (
+        items
+      ) : (
+        <NoOrder>진행중인 내역이 없습니다...</NoOrder>
+      )}
+      {userRole === 'MANAGER' && items.length === 0 && (
+        <NoOrder>요청 내역이 없습니다...</NoOrder>
+      )}
     </Container>
   );
 }

--- a/packages/client/src/components/OrderDetailList/index.tsx
+++ b/packages/client/src/components/OrderDetailList/index.tsx
@@ -1,14 +1,14 @@
 import React, { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
-import axios from 'axios';
 
 import { OrderDetailMenu, OrderStatusCode } from '@/types';
-import { getPriceComma } from '@/utils';
+import { getFirstUpper, getPriceComma } from '@/utils';
 import {
   ButtonContainer,
   Container,
   DivisionLine,
   ItemContainer,
+  OptionContainer,
   OptionText,
   PriceText,
 } from './styled';
@@ -58,16 +58,24 @@ function ButtonGroup({ status, onClick }: ButtonGroupProps) {
 function OrderDetailItem({ date, menu }: ItemProps) {
   return (
     <>
-      <ItemContainer key={`${date}-${menu.id}`}>
-        <p>
-          {menu.name} {menu.count}잔
-        </p>
-        <PriceText>{`${getPriceComma(menu.price)} 원`}</PriceText>
-      </ItemContainer>
       <div>
-        {Object.keys(menu.options).map((k) => (
-          <OptionText key={menu.options[k]}>{menu.options[k]}</OptionText>
-        ))}
+        <ItemContainer key={`${date}-${menu.id}`}>
+          <p>
+            {menu.name} {menu.count}잔
+          </p>
+          <PriceText>{`${getPriceComma(menu.price)} 원`}</PriceText>
+        </ItemContainer>
+        <OptionContainer>
+          <OptionText>
+            {(menu?.type ?? 'HOT').toUpperCase()} |{' '}
+            {getFirstUpper(menu.size ?? 'Tall')}
+          </OptionText>
+          {Object.keys(menu.options).map((k) => (
+            <OptionText key={menu.options[k]} isOption>
+              {menu.options[k]}
+            </OptionText>
+          ))}
+        </OptionContainer>
       </div>
     </>
   );
@@ -75,7 +83,7 @@ function OrderDetailItem({ date, menu }: ItemProps) {
 
 function OrderDetailList({ date, menus, status, onClick }: Props) {
   const userRole = useRecoilValue(userRoleState);
-
+  console.log(menus);
   const totalPrice = useMemo(() => {
     return menus.reduce((prev, curr) => prev + curr.price, 0);
   }, [menus]);

--- a/packages/client/src/components/OrderDetailList/styled.ts
+++ b/packages/client/src/components/OrderDetailList/styled.ts
@@ -17,6 +17,10 @@ export const ItemContainer = styled.div`
   align-items: center;
 `;
 
+export const OptionContainer = styled.div`
+  padding: 0.3rem 0;
+`;
+
 export const DivisionLine = styled.div`
   height: 1px;
   /* 
@@ -37,8 +41,8 @@ export const ButtonContainer = styled.div`
   gap: 1rem;
 `;
 
-export const OptionText = styled.p`
-  padding: 0.2rem;
+export const OptionText = styled.p<{ isOption?: boolean }>`
+  padding: ${(props) => (props.isOption ? '0' : '0.2rem')} 0;
   font-size: ${(props) => props.theme.font.size.xs};
   color: ${(props) => props.theme.colors.grey400};
 `;

--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -91,6 +91,8 @@ export interface OrderDetailMenu {
   price: number;
   count?: number;
   thumbnail?: string;
+  type?: Temperature;
+  size?: Size;
 }
 
 // OrderList.tsx


### PR DESCRIPTION

## 📕 업주 주문 내역 페이지 수정

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 업주 주문 내역 페이지 옵션 정보 렌더링 추가 (음료 타입, 사이즈)
- [x] 업주 주문 내역 비어있는 경우, 알림 텍스트 제공
